### PR TITLE
Faust fixes

### DIFF
--- a/FaustCode/owl.cpp
+++ b/FaustCode/owl.cpp
@@ -38,6 +38,11 @@
 
 #include "Patch.h"
 
+// We have to undefine min/max from Owl's basicmaths.h, otherwise they cause errors
+// when Faust calls functions with the same names in std:: namespace
+#undef min
+#undef max
+
 #include <string.h>
 #include <strings.h>
 

--- a/FaustCode/owl.cpp
+++ b/FaustCode/owl.cpp
@@ -144,18 +144,23 @@ enum ParserState {
 // This is a parser for Faust metadata. Currently it only reacts on midi declaration, but
 // this can be extended in processItem class.
 // To enable MIDI in current patch, add this to source Faust file:
-// declare options "[midi:on]";
+//     declare options "[midi:on]";
+// You can also add descrpiption to be displayed with debugMessage function like this:
+//     declare message "Hello World";
 
 class MetaData : public Meta {
 public:
   bool midiOn = false;
+  const char* message = NULL;
 
   void declare (const char* key, const char* value) {
     if (strcasecmp(key, "options") == 0) {
       // Parse options.
       // Faust provides a metadata parser, but they use stdlib stuff that won't work on OWL
       parseOptions(value);
-
+    }
+    else if (strcasecmp(key, "message") == 0) {
+      message = value;
     }
   }
 
@@ -490,6 +495,8 @@ public:
     fBend = 1.0f;
     fDSP = new mydsp();
     fDSP->metadata(&fUI.meta);
+    if (fUI.meta.message != NULL)
+      debugMessage(fUI.meta.message);
     mydsp::fManager = &mem; // set custom memory manager
     mydsp::classInit(int(getSampleRate())); // initialise static tables
     fDSP->instanceInit(int(getSampleRate())); // initialise DSP instance

--- a/FaustCode/owl.cpp
+++ b/FaustCode/owl.cpp
@@ -163,9 +163,10 @@ protected:
   float	fSpan;			// Faust widget value span (max-min)
 	
 public:
-  OwlParameter(Patch* pp, PatchParameterId param, FAUSTFLOAT* z, const char* l, float lo, float hi) :
+  OwlParameter(Patch* pp, PatchParameterId param, FAUSTFLOAT* z, const char* l, float init, float lo, float hi) :
     OwlParameterBase(pp, z), fParameter(param), fMin(lo), fSpan(hi-lo) {
     fPatch->registerParameter(param, l);
+    fPatch->setParameterValue(fParameter, (init - lo) / fSpan);
   }
   void update()	{ *fZone = fMin + fSpan*fPatch->getParameterValue(fParameter); }
 	
@@ -179,8 +180,9 @@ protected:
   float	fHi;			// Faust widget value span (max-min)
 	
 public:
-  OwlVariable(Patch* pp, float* t, FAUSTFLOAT* z, const char* l, float lo, float hi) :
+  OwlVariable(Patch* pp, float* t, FAUSTFLOAT* z, const char* l, float init, float lo, float hi) :
     OwlParameterBase(pp, z), fValue(t), fLo(lo), fHi(hi) {
+    *fZone = init;
   }
   void update()	{
     float value = *fValue;
@@ -226,16 +228,16 @@ class OwlUI : public UI
   OwlParameterBase* fParameterTable[MAXOWLPARAMETERS];
   PatchButtonId fButton;
   // check if the widget is an Owl parameter and, if so, add the corresponding OwlParameter
-  void addOwlParameter(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi) {
+  void addOwlParameter(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi) {
     if(fParameterIndex < MAXOWLPARAMETERS){
       if(strcasecmp(label,"freq") == 0){
-	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fFreq, zone, label, lo, hi);
+	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fFreq, zone, label, init, lo, hi);
       }else if(strcasecmp(label,"gain") == 0){
-	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fGain, zone, label, lo, hi);
+	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fGain, zone, label, init, lo, hi);
       }else if(strcasecmp(label,"bend") == 0){
-	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fBend, zone, label, lo, hi);
+	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fBend, zone, label, init, lo, hi);
       }else if(fParameter != NO_PARAMETER){
-	fParameterTable[fParameterIndex++] = new OwlParameter(fPatch, fParameter, zone, label, lo, hi);
+	fParameterTable[fParameterIndex++] = new OwlParameter(fPatch, fParameter, zone, label, init, lo, hi);
       }
     }
     fParameter = NO_PARAMETER; 		// clear current parameter ID
@@ -244,7 +246,7 @@ class OwlUI : public UI
   void addOwlButton(const char* label, FAUSTFLOAT* zone) {
     if(fParameterIndex < MAXOWLPARAMETERS){
       if(strcasecmp(label,"gate") == 0){
-	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fGate, zone, label, 0.0f, 1.0f);
+	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fGate, zone, label, 0.0f, 0.0f, 1.0f);
       }else if(fButton != NO_BUTTON){
 	fParameterTable[fParameterIndex++] = new OwlButton(fPatch, fButton, zone, label);
       }
@@ -286,9 +288,9 @@ public:
 
   virtual void addButton(const char* label, FAUSTFLOAT* zone) 																			{ addOwlButton(label, zone); }
   virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) 																		{ addOwlButton(label, zone); }
-  virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) 	{ addOwlParameter(label, zone, lo, hi); }
-  virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) 	{ addOwlParameter(label, zone, lo, hi); }
-  virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) 			{ addOwlParameter(label, zone, lo, hi); }
+  virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) 	{ addOwlParameter(label, zone, init, lo, hi); }
+  virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) 	{ addOwlParameter(label, zone, init, lo, hi); }
+  virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) 			{ addOwlParameter(label, zone, init, lo, hi); }
 
   // -- passive widgets
 

--- a/Source/faustmath.h
+++ b/Source/faustmath.h
@@ -1,0 +1,59 @@
+#ifndef __fastmath_h__
+#define __fastmath_h__
+
+#include "basicmaths.h"
+
+// This file extends functions from basicmaths.h with all function names
+// used by Faust fast maths calls.
+
+// For reference, see
+// https://github.com/grame-cncm/faust/blob/master-dev/compiler/global.cpp#L173-L215
+
+// Float versions
+
+#define fast_acosf(x) acosf(x)
+#define fast_asinf(x) asinf(x)
+#define fast_atanf(x) atanf(x)
+#define fast_atan2f(x, y) atan2f(x, y) // Optimized for ARM
+#define fast_ceilf(x) ceilf(x)
+#define fast_cosf(x) cosf(x) // Optimized for ARM
+// fast_expf is defined in basicmath.h
+// fast_exp2f is defined in basicmath.h
+// fast_exp10f is defined in basicmath.h
+#define fast_floorf(x) floorf(x)
+#define fast_fmodf(x, y) fmodf(x, y)
+// fast_logf is defined in basicmath.h
+// fast_log2f is defined in basicmath.h
+// fast_log10f is defined in basicmath.h
+// fast_powf is defined in basicmath.h
+#define fast_remainderf(x, y) remainderf(x, y)
+#define fast_roundf(x) roundf(x)
+#define fast_sinf(x) sinf(x) // Optimized for ARM
+#define fast_sqrtf(x) sqrtf(x) // Optimized for ARM
+#define fast_tanf(x) tanf(x)
+
+// Double versions
+
+// Actually, we'll end up calling float versions and casting them to doubles.
+#define fast_acos(x) fast_acosf(x)
+#define fast_asin(x) fast_asinf(x)
+#define fast_atan(x) fast_atanf(x)
+#define fast_atan2(x, y) fast_atan2f(x, y)
+#define fast_ceil(x) fast_ceilf(x)
+#define fast_cos(x) fast_cosf(x)
+#define fast_exp(x) fast_expf(x)
+#define fast_exp2(x, y) fast_exp2f(x, y)
+#define fast_exp10(x) fast_exp10f(x)
+#define fast_floor(x) fast_floorf(x)
+#define fast_fmod(x, y) fast_fmodf(x, y)
+#define fast_log(x) fast_logf(x)
+#define fast_log2(x) fast_log2f(x)
+#define fast_log10(x) fast_log10f(x)
+#define fast_pow(x, y) fast_powf(x, y)
+#define fast_remainder(x, y) fast_remainderf(x, y)
+#define fast_round(x) fast_roundf(x)
+#define fast_sin(x) fast_sinf(x)
+#define fast_sqrt(x) fast_sqrtf(x)
+#define fast_tan(x) fast_tanf(x)
+
+#endif

--- a/faust.mk
+++ b/faust.mk
@@ -3,9 +3,9 @@ FAUSTCC ?= faust
 faust: $(BUILD)/Source/FaustPatch.hpp
 
 $(BUILD)/Source/FaustPatch.hpp: $(PATCHSOURCE)/$(FAUST).dsp
-	@$(FAUSTCC) $(FAUSTFLAGS) -I $(PATCHSOURCE) -i -inpl -mem -a FaustCode/owl.cpp $< -o $@
+	@$(FAUSTCC) $(FAUSTFLAGS) -I $(PATCHSOURCE) -i -inpl -mem -a FaustCode/owl.cpp -fm faustmath.h $< -o $@
 	@cp FaustCode/owl.h $(PATCHSOURCE)
 
 $(BUILD)/Source/%Patch.hpp: $(PATCHSOURCE)/%.dsp
-	@$(FAUSTCC) $(FAUSTFLAGS) -I $(PATCHSOURCE) -i -inpl -mem -a FaustCode/owl.cpp $< -o $@
+	@$(FAUSTCC) $(FAUSTFLAGS) -I $(PATCHSOURCE) -i -inpl -mem -a FaustCode/owl.cpp -fm faustmath.h $< -o $@
 


### PR DESCRIPTION
I've made some updates for Faust arch file that allows building with its latest version. It also adds quite a few features for functionality provided by Magus. Specifically:

* Resolve conflict for min/max functions when they are called in std namespace by faust generated code
* Added fast_math file definitions with all function names that Faust uses in its default file. This is required because faust generated calls calls them either from std namespace or from user-provided file with fast_ prefixes - and std namespace is getting conflicts due to names from basicmaths file
* Pass default values to parameter widgets (needed since we have encoders and not pots, so they don't get overridden by current values)
* Output parameters added! This is done by defining them as vbargraph/hbargraph widgets (this is standard way to do it in Faust). Note: they require ">" in label for output, since we don't have access to IO state programmatically?
* Parse global Faust metadata. This is used for next 2 features
* Allow adding metadata that prints debug message (i.e. for patch description)
* Disable functionality related by MidiAllocator by default, only initialize it if "[midi:on]" is declared. Rationale:  current behavior converts parameters with certain labels (freq, gain, gate) into variables, so they disappear from Magus UI even if there's a parameter bound.