### PR TITLE
Voct convertion support for Faust

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,33 @@
+﻿---
+BasedOnStyle: WebKit
+BreakBeforeBinaryOperators: None
+ColumnLimit: '80'
+CompactNamespaces: 'false'
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: 'false'
+Standard: Cpp11
+TabWidth: '4'
+UseTab: Never
+AlwaysBreakTemplateDeclarations: 'Yes'
+IndentWidth: '4'
+ContinuationIndentWidth: '4'
+AllowShortFunctionsOnASingleLine: None
+PenaltyExcessCharacter: '2'
+PointerAlignment: 'Left'
+SortIncludes: 'false'
+SpaceBeforeParens: ControlStatements
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      true
+  IndentBraces:    false
+
+...

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 *.app
 
 Source/progname.s
+
+#Unignore this - because .lib extension is ignored for libraries
+!FaustCode/owl.lib

--- a/FaustCode/owl.cpp
+++ b/FaustCode/owl.cpp
@@ -1,9 +1,9 @@
 /************************************************************************
 
-	IMPORTANT NOTE : this file contains two clearly delimited sections :
-	the ARCHITECTURE section (in two parts) and the USER section. Each section
-	is governed by its own copyright and license. Please check individually
-	each section for license and copyright information.
+    IMPORTANT NOTE : this file contains two clearly delimited sections :
+    the ARCHITECTURE section (in two parts) and the USER section. Each section
+    is governed by its own copyright and license. Please check individually
+    each section for license and copyright information.
 *************************************************************************/
 
 /*******************BEGIN ARCHITECTURE SECTION (part 1/2)****************/
@@ -37,9 +37,10 @@
 #define __FaustPatch_h__
 
 #include "Patch.h"
+#include "VoltsPerOctave.h"
 
-// We have to undefine min/max from Owl's basicmaths.h, otherwise they cause errors
-// when Faust calls functions with the same names in std:: namespace
+// We have to undefine min/max from Owl's basicmaths.h, otherwise they cause
+// errors when Faust calls functions with the same names in std:: namespace
 #undef min
 #undef max
 
@@ -57,509 +58,700 @@ static float fFreq, fGain, fGate;
 static float fBend = 1.0f;
 
 class MonoVoiceAllocator {
-  float& freq;
-  float& gain;
-  float& gate;
-  float& bend;
-  uint8_t notes[16];
-  uint8_t lastNote = 0;
-public:
-  MonoVoiceAllocator(float& fq, float& gn, float& gt, float& bd): freq(fq), gain(gn), gate(gt), bend(bd) {
-  }
-  float getFreq(){
-    return freq;
-  }
-  float getGain(){
-    return gain;
-  }
-  float getGate(){
-    return gate;
-  }
-  float getBend(){
-    return bend;
-  }
-  void processMidi(MidiMessage msg){
-    uint16_t samples = 0;
-    if(msg.isNoteOn()){
-      noteOn(msg.getNote(), (uint16_t)msg.getVelocity()<<5, samples);
-    }else if(msg.isNoteOff()){
-      noteOff(msg.getNote(), (uint16_t)msg.getVelocity()<<5, samples);      
-    }else if(msg.isPitchBend()){
-      setPitchBend(msg.getPitchBend());
-    }else if(msg.isControlChange()){
-      if(msg.getControllerNumber() == MIDI_ALL_NOTES_OFF)
-	allNotesOff();
-    }
-  }
-  void setPitchBend(int16_t pb){
-    float fb = pb*(2.0f/8192.0f);
-    bend = exp2f(fb);
-  }
-  float noteToHz(uint8_t note){
-    return 440.0f*exp2f((note-69)/12.0);
-  }
-  float velocityToGain(uint16_t velocity){
-    return exp2f(velocity/4095.0f) -1;
-    // return powf((1.0-depth) + (velocity/127.0*depth), 2.0);
-  }
-  void noteOn(uint8_t note, uint16_t velocity, uint16_t delay){
-    if(lastNote < 16)
-      notes[lastNote++] = note;
-    freq = noteToHz(note);
-    gain = velocityToGain(velocity);
-    gate = 1;
-  }
-  void noteOff(uint8_t note, uint16_t velocity, uint16_t delay){
-    int i;
-    for(i=0; i<lastNote; ++i){
-      if(notes[i] == note)
-    	break;
-    }
-    if(lastNote > 1){
-      lastNote--;
-      while(i<lastNote){
-	notes[i] = notes[i+1];
-	i++;
-      }
-      freq = noteToHz(notes[lastNote-1]);
-    }else{
-      gate = 0;
-      lastNote = 0;
-    }
-  }
-  void allNotesOff(){
-    lastNote = 0;
-    bend = 0;
-  }
-};
+    float& freq;
+    float& gain;
+    float& gate;
+    float& bend;
+    uint8_t notes[16];
+    uint8_t lastNote = 0;
 
+public:
+    MonoVoiceAllocator(float& fq, float& gn, float& gt, float& bd)
+        : freq(fq)
+        , gain(gn)
+        , gate(gt)
+        , bend(bd) {
+    }
+    float getFreq() {
+        return freq;
+    }
+    float getGain() {
+        return gain;
+    }
+    float getGate() {
+        return gate;
+    }
+    float getBend() {
+        return bend;
+    }
+    void processMidi(MidiMessage msg) {
+        uint16_t samples = 0;
+        if (msg.isNoteOn()) {
+            noteOn(msg.getNote(), (uint16_t)msg.getVelocity() << 5, samples);
+        }
+        else if (msg.isNoteOff()) {
+            noteOff(msg.getNote(), (uint16_t)msg.getVelocity() << 5, samples);
+        }
+        else if (msg.isPitchBend()) {
+            setPitchBend(msg.getPitchBend());
+        }
+        else if (msg.isControlChange()) {
+            if (msg.getControllerNumber() == MIDI_ALL_NOTES_OFF)
+                allNotesOff();
+        }
+    }
+    void setPitchBend(int16_t pb) {
+        float fb = pb * (2.0f / 8192.0f);
+        bend = exp2f(fb);
+    }
+    float noteToHz(uint8_t note) {
+        return 440.0f * exp2f((note - 69) / 12.0);
+    }
+    float velocityToGain(uint16_t velocity) {
+        return exp2f(velocity / 4095.0f) - 1;
+        // return powf((1.0-depth) + (velocity/127.0*depth), 2.0);
+    }
+    void noteOn(uint8_t note, uint16_t velocity, uint16_t delay) {
+        if (lastNote < 16)
+            notes[lastNote++] = note;
+        freq = noteToHz(note);
+        gain = velocityToGain(velocity);
+        gate = 1.0f;
+    }
+    void noteOff(uint8_t note, uint16_t velocity, uint16_t delay) {
+        int i;
+        for (i = 0; i < lastNote; ++i) {
+            if (notes[i] == note)
+                break;
+        }
+        if (lastNote > 1) {
+            lastNote--;
+            while (i < lastNote) {
+                notes[i] = notes[i + 1];
+                i++;
+            }
+            freq = noteToHz(notes[lastNote - 1]);
+        }
+        else {
+            gate = 0.0f;
+            lastNote = 0;
+        }
+    }
+    void allNotesOff() {
+        lastNote = 0;
+        bend = 0;
+    }
+};
 
 enum ParserState {
-   ST_NONE,
-   ST_KEY,
-   ST_VALUE
+    ST_NONE,
+    ST_KEY,
+    ST_VALUE,
 };
 
-
-// This is a parser for Faust metadata. Currently it only reacts on midi declaration, but
-// this can be extended in processItem class.
-// To enable MIDI in current patch, add this to source Faust file:
-//     declare options "[midi:on]";
-// You can also add descrpiption to be displayed with debugMessage function like this:
-//     declare message "Hello World";
+/*************************************************************************************
+ * To enable MIDI in current patch, add this to source Faust file:
+ *     declare options "[midi:on]";
+ *
+ * You can also add descrpiption to be displayed with debugMessage function like
+ * this:
+ *     declare message "Hello World";
+ *
+ * To add V/Oct scaling support, use something likes this:
+ *     declare owl "[voct:input][voct:output]";
+ * Declaring just one V/Oct converter or both of them is fine.
+ **************************************************************************************/
 
 class MetaData : public Meta {
 public:
-  bool midiOn = false;
-  const char* message = NULL;
+    bool midiOn = false;
+    const char* message = NULL;
+    bool vOctInput = false;
+    bool vOctOutput = false;
 
-  void declare (const char* key, const char* value) {
-    if (strcasecmp(key, "options") == 0) {
-      // Parse options.
-      // Faust provides a metadata parser, but they use stdlib stuff that won't work on OWL
-      parseOptions(value);
+    void declare(const char* key, const char* value) {
+        /*
+          This function would be called by Faust compiler based on metadata
+          declared in source file.
+         */
+        if (strcasecmp(key, "options") == 0) {
+            // Parse options.
+            // Faust provides a metadata parser, but they use stdlib stuff that won't work on OWL
+            parseOptions(key, value);
+        }
+        else if (strcasecmp(key, "message") == 0) {
+            message = value;
+        }
+        else if (strcasecmp(key, "owl") == 0) {
+            parseOptions(key, value);
+        }
     }
-    else if (strcasecmp(key, "message") == 0) {
-      message = value;
-    }
-  }
 
 private:
-  void processItem(const char* item_key, const char* item_value) {
-    if (strcasecmp(item_key, "midi") == 0 && strcasecmp(item_value, "on") == 0) {
-      midiOn = true;
-      //debugMessage("MIDI ON");
+    void processItem(const char* key, const char* item_key, const char* item_value) {
+        if (strcasecmp(key, "options") == 0 && strcasecmp(item_key, "midi") == 0 &&
+            strcasecmp(item_value, "on") == 0) {
+            midiOn = true;
+        }
+        else if (strcasecmp(key, "owl") == 0 && strcasecmp(item_key, "voct") == 0) {
+            if (strcasecmp(item_value, "input") == 0) {
+                vOctInput = true;
+            }
+            else if (strcasecmp(item_value, "output") == 0) {
+                vOctOutput = true;
+            }
+        }
     }
-  }
 
-  void parseOptions(const char* value) {
-    const char* c = value;
-    const uint8_t max_len = 32;
-    // We don't need to read long item values, so set a limit that would be used for truncating them.
-    char item_key[max_len] = "";
-    char item_value[max_len] = "";
-    uint8_t key_pos;
-    uint8_t value_pos;
-    ParserState state = ST_NONE;
-    while (*c) {
-      if (state == ST_NONE) {
-	if (*c == '[') {
-	  // Start reading key
-	  state = ST_KEY;
-	  key_pos = 0;
-	  value_pos = 0;
-	}
-      }
-      else if (state == ST_KEY) {
-	if (*c == ':') {
-	  // Found end of key
-	  item_key[key_pos + 1] = '\n';
-	  // Start reading value
-	  state = ST_VALUE;
-	}
-	else if (key_pos < max_len - 1)
-	  // Add next character to key
-	    item_key[key_pos++] = *c;
-      }
-      else if (state == ST_VALUE) {
-	if  (*c == ']') {
-	  // Found end of value
-	  item_value[value_pos + 1] = '\n';
-	  processItem(item_key, item_value);
-	  // Reset state
-	  state = ST_NONE;
-	}
-	else if (value_pos < max_len -  1)
-	  // Add next character to value
-	  item_value[value_pos++] = *c;
-      };
-      c++;
+    void parseOptions(const char* key, const char* value) {
+        const char* c = value;
+        const uint8_t max_len = 32;
+        // We don't need to read long item values, so set a limit that would be used for truncating them.
+        char item_key[max_len] = "";
+        char item_value[max_len] = "";
+        uint8_t key_pos;
+        uint8_t value_pos;
+        ParserState state = ST_NONE;
+        while (*c) {
+            if (state == ST_NONE) {
+                if (*c == '[') {
+                    // Start reading key
+                    state = ST_KEY;
+                    key_pos = 0;
+                    value_pos = 0;
+                }
+            }
+            else if (state == ST_KEY) {
+                if (*c == ':') {
+                    // Found end of key
+                    item_key[key_pos + 1] = '\n';
+                    // Start reading value
+                    state = ST_VALUE;
+                }
+                else if (key_pos < max_len - 1)
+                    // Add next character to key
+                    item_key[key_pos++] = *c;
+            }
+            else if (state == ST_VALUE) {
+                if (*c == ']') {
+                    // Found end of value
+                    item_value[value_pos + 1] = '\n';
+                    processItem(key, item_key, item_value);
+                    // Reset state
+                    state = ST_NONE;
+                }
+                else if (value_pos < max_len - 1)
+                    // Add next character to value
+                    item_value[value_pos++] = *c;
+            };
+            c++;
+        }
     }
-  }
 };
 
 /**************************************************************************************
+ *
+ * OwlParameter : object used by OwlUI to ensures the connection between an Owl
+ * parameter and a Faust widget
+ *
+ ***************************************************************************************/
 
-	OwlParameter : object used by OwlUI to ensures the connection between an owl parameter 
-	and a faust widget
-	
-***************************************************************************************/
-
-class OwlParameterBase
-{
+class OwlParameterBase {
 protected:
-  Patch* fPatch;      // needed to register and read owl parameters
-  FAUSTFLOAT* fZone;  // Faust widget zone
-  bool isOutput;
-public:
-  OwlParameterBase(Patch* pp, FAUSTFLOAT* z, bool output) :
-    fPatch(pp), fZone(z), isOutput(output) {}
-  virtual void update()	{}
-};
+    Patch* fPatch; // needed to register and read owl parameters
+    FAUSTFLOAT* fZone; // Faust widget zone
+    bool isOutput;
 
-class OwlParameter : public OwlParameterBase
-{
-protected:
-  PatchParameterId fParameter;	// OWL parameter code : PARAMETER_A,...
-  float	fMin;			// Faust widget minimal value
-  float	fSpan;			// Faust widget value span (max-min)
-	
 public:
-  OwlParameter(Patch* pp, PatchParameterId param, FAUSTFLOAT* z, const char* l, float init, float lo, float hi, bool output=false) :
-    OwlParameterBase(pp, z, output), fParameter(param), fMin(lo), fSpan(hi-lo) {
-    fPatch->registerParameter(param, l);
-    fPatch->setParameterValue(fParameter, (init - lo) / fSpan);
-  }
-  void update()	{
-    if (isOutput) {
-      fPatch->setParameterValue(fParameter, (*fZone - fMin) / fSpan);
+    OwlParameterBase(Patch* pp, FAUSTFLOAT* z, bool output)
+        : fPatch(pp)
+        , fZone(z)
+        , isOutput(output) {
     }
-    else
-      *fZone = fMin + fSpan*fPatch->getParameterValue(fParameter);
-	
-  }
-};
-
-class OwlVariable : public OwlParameterBase
-{
-protected:
-  float* fValue;
-  float	fLo;			// Faust widget minimal value
-  float	fHi;			// Faust widget value span (max-min)
-	
-public:
-  OwlVariable(Patch* pp, float* t, FAUSTFLOAT* z, const char* l, float init, float lo, float hi, bool output=false) :
-    OwlParameterBase(pp, z, output), fValue(t), fLo(lo), fHi(hi) {
-    *fZone = init;
-  }
-  void update()	{
-    if (isOutput) {
-      // We don't output OwlVariable anywhere, so would this even be useful?
-      *fValue = *fZone;
+    virtual void update() {
     }
-    else {
-      float value = *fValue;
-      // clip value to min/max
-      value = value > fLo ? (value < fHi ? value : fHi) : fLo;
-      *fZone = value;
-    }
-  }  	
+    virtual ~OwlParameterBase() {}; // Not adding virtual destructor triggers undefined behavior
 };
 
-class OwlButton : public OwlParameterBase
-{
+class OwlParameter : public OwlParameterBase {
 protected:
-  PatchButtonId	fButton;		// OWL button id : PUSHBUTTON, ...
+    PatchParameterId fParameter; // OWL parameter code : PARAMETER_A,...
+    float fMin; // Faust widget minimal value
+    float fSpan; // Faust widget value span (max-min)
+
 public:
-  OwlButton(Patch* pp, PatchButtonId button, FAUSTFLOAT* z, const char* l) :
-    OwlParameterBase(pp, z, true), fButton(button) {}
-  void update()	{ *fZone = fPatch->isButtonPressed(fButton); }
+    OwlParameter(Patch* pp, PatchParameterId param, FAUSTFLOAT* z,
+        const char* l, float init, float lo, float hi, bool output = false)
+        : OwlParameterBase(pp, z, output)
+        , fParameter(param)
+        , fMin(lo)
+        , fSpan(hi - lo) {
+        fPatch->registerParameter(param, l);
+        fPatch->setParameterValue(fParameter, (init - lo) / fSpan);
+    }
+    void update() {
+        if (isOutput) {
+            fPatch->setParameterValue(fParameter, (*fZone - fMin) / fSpan);
+        }
+        else
+            *fZone = fMin + fSpan * fPatch->getParameterValue(fParameter);
+    }
+    ~OwlParameter() {};
 };
 
+class OwlVariable : public OwlParameterBase {
+protected:
+    float* fValue;
+    float fLo; // Faust widget minimal value
+    float fHi; // Faust widget value span (max-min)
+
+public:
+    OwlVariable(Patch* pp, float* t, FAUSTFLOAT* z, const char* l, float init,
+        float lo, float hi, bool output = false)
+        : OwlParameterBase(pp, z, output)
+        , fValue(t)
+        , fLo(lo)
+        , fHi(hi) {
+        *fZone = init;
+    }
+    void update() {
+        if (isOutput) {
+            // We don't output OwlVariable anywhere, so would this even be useful?
+            *fValue = *fZone;
+        }
+        else {
+            float value = *fValue;
+            // clip value to min/max
+            value = value > fLo ? (value < fHi ? value : fHi) : fLo;
+            *fZone = value;
+        }
+    }
+    ~OwlVariable() {};
+};
+
+class OwlButton : public OwlParameterBase {
+protected:
+    PatchButtonId fButton; // OWL button id : PUSHBUTTON, ...
+public:
+    OwlButton(Patch* pp, PatchButtonId button, FAUSTFLOAT* z, const char* l)
+        : OwlParameterBase(pp, z, true)
+        , fButton(button) {
+    }
+    void update() {
+        *fZone = fPatch->isButtonPressed(fButton);
+    }
+    ~OwlButton() {};
+};
 
 /**************************************************************************************
+ *
+ * OwlUI : Faust User Interface builder. Passed to buildUserInterface OwlU
+ * ensures the mapping between owl parameters and faust widgets. It relies on
+ * specific metadata "...[OWL:PARAMETER_X]..." in widget's label for that. For
+ * example any faust widget with metadata [OWL:PARAMETER_B] will be controlled
+ * by PARAMETER_B (the second knob).
+ *
+ ***************************************************************************************/
 
-	OwlUI : Faust User Interface builder. Passed to buildUserInterface OwlUI ensures
-	the mapping between owl parameters and faust widgets. It relies on specific
-	metadata "...[OWL:PARAMETER_X]..." in widget's label for that. For example any 
-	faust widget with metadata [OWL:PARAMETER_B] will be controlled by PARAMETER_B 
-	(the second knob).
-	
-***************************************************************************************/
-
-// The maximun number of mappings between owl parameters and faust widgets 
+// The maximun number of mappings between owl parameters and faust widgets
 #define MAXOWLPARAMETERS 20
-#define NO_PARAMETER     ((PatchParameterId)-1)
-#define NO_BUTTON        ((PatchButtonId)-1)
+#define NO_PARAMETER ((PatchParameterId)-1)
+#define NO_BUTTON ((PatchButtonId)-1)
 
 MonoVoiceAllocator allocator(fFreq, fGain, fGate, fBend);
+VoltsPerOctave* fVOctInput;
+VoltsPerOctave* fVOctOutput;
 
-class OwlUI : public UI
-{
-  Patch* fPatch;
-  PatchParameterId fParameter;					// current parameter ID, value NO_PARAMETER means not set
-  int fParameterIndex = 0;						// number of OwlParameters collected so far
-  OwlParameterBase* fParameterTable[MAXOWLPARAMETERS];
-  PatchButtonId fButton;
-  // check if the widget is an Owl parameter and, if so, add the corresponding OwlParameter
-  void addInputOwlParameter(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi) {
-    if(fParameterIndex < MAXOWLPARAMETERS){
-      if(meta.midiOn && strcasecmp(label,"freq") == 0){
-	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fFreq, zone, label, init, lo, hi);
-      }else if(meta.midiOn && strcasecmp(label,"gain") == 0){
-	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fGain, zone, label, init, lo, hi);
-      }else if(meta.midiOn && strcasecmp(label,"bend") == 0){
-	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fBend, zone, label, init, lo, hi);
-      }else if(fParameter != NO_PARAMETER){
-	fParameterTable[fParameterIndex++] = new OwlParameter(fPatch, fParameter, zone, label, init, lo, hi);
-      }
+class OwlUI : public UI {
+    Patch* fPatch;
+    PatchParameterId fParameter; // current parameter ID, value NO_PARAMETER means not set
+    int fParameterIndex = 0; // number of OwlParameters collected so far
+    OwlParameterBase* fParameterTable[MAXOWLPARAMETERS];
+    PatchButtonId fButton;
+    // check if the widget is an Owl parameter and, if so, add the corresponding OwlParameter
+    void addInputOwlParameter(const char* label, FAUSTFLOAT* zone,
+        FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi) {
+        if (fParameterIndex < MAXOWLPARAMETERS) {
+            if (meta.midiOn && strcasecmp(label, "freq") == 0) {
+                fParameterTable[fParameterIndex++] =
+                    new OwlVariable(fPatch, &fFreq, zone, label, init, lo, hi);
+            }
+            else if (meta.midiOn && strcasecmp(label, "gain") == 0) {
+                fParameterTable[fParameterIndex++] =
+                    new OwlVariable(fPatch, &fGain, zone, label, init, lo, hi);
+            }
+            else if (meta.midiOn && strcasecmp(label, "bend") == 0) {
+                fParameterTable[fParameterIndex++] =
+                    new OwlVariable(fPatch, &fBend, zone, label, init, lo, hi);
+            }
+            else if (fParameter != NO_PARAMETER) {
+                fParameterTable[fParameterIndex++] =
+                    new OwlParameter(fPatch, fParameter, zone, label, init, lo, hi);
+            }
+        }
+        fParameter = NO_PARAMETER; // clear current parameter ID
     }
-    fParameter = NO_PARAMETER; 		// clear current parameter ID
-  }
 
-  void addOutputOwlParameter(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi) {
-    if(fParameterIndex < MAXOWLPARAMETERS){
-      if(meta.midiOn && strcasecmp(label,"freq") == 0){
-	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fFreq, zone, label, lo, lo, hi, true);
-      }else if(meta.midiOn && strcasecmp(label,"gain") == 0){
-	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fGain, zone, label, lo, lo, hi, true);
-      }else if(meta.midiOn && strcasecmp(label,"bend") == 0){
-	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fBend, zone, label, lo, lo, hi, true);
-      }else if(fParameter != NO_PARAMETER){
-	fParameterTable[fParameterIndex++] = new OwlParameter(fPatch, fParameter, zone, label, lo, lo, hi, true);
-      }
+    void addOutputOwlParameter(
+        const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi) {
+        ASSERT(label[strlen(label) - 1] == '>',
+            "You must add '>' character for output parameters");
+        if (fParameterIndex < MAXOWLPARAMETERS) {
+            if (meta.midiOn && strcasecmp(label, "freq") == 0) {
+                fParameterTable[fParameterIndex++] =
+                    new OwlVariable(fPatch, &fFreq, zone, label, lo, lo, hi, true);
+            }
+            else if (meta.midiOn && strcasecmp(label, "gain") == 0) {
+                fParameterTable[fParameterIndex++] =
+                    new OwlVariable(fPatch, &fGain, zone, label, lo, lo, hi, true);
+            }
+            else if (meta.midiOn && strcasecmp(label, "bend") == 0) {
+                fParameterTable[fParameterIndex++] =
+                    new OwlVariable(fPatch, &fBend, zone, label, lo, lo, hi, true);
+            }
+            else if (fParameter != NO_PARAMETER) {
+                fParameterTable[fParameterIndex++] = new OwlParameter(
+                    fPatch, fParameter, zone, label, lo, lo, hi, true);
+            }
+        }
+        fParameter = NO_PARAMETER; // clear current parameter ID
     }
-    fParameter = NO_PARAMETER; 		// clear current parameter ID
-  }
 
-  void addOwlButton(const char* label, FAUSTFLOAT* zone) {
-    if(fParameterIndex < MAXOWLPARAMETERS){
-      if(meta.midiOn && strcasecmp(label,"gate") == 0){
-	fParameterTable[fParameterIndex++] = new OwlVariable(fPatch, &fGate, zone, label, 0.0f, 0.0f, 1.0f);
-      }else if(fButton != NO_BUTTON){
-	fParameterTable[fParameterIndex++] = new OwlButton(fPatch, fButton, zone, label);
-      }
+    void addOwlButton(const char* label, FAUSTFLOAT* zone) {
+        if (fParameterIndex < MAXOWLPARAMETERS) {
+            if (meta.midiOn && strcasecmp(label, "gate") == 0) {
+                fParameterTable[fParameterIndex++] =
+                    new OwlVariable(fPatch, &fGate, zone, label, 0.0f, 0.0f, 1.0f);
+            }
+            else if (fButton != NO_BUTTON) {
+                fParameterTable[fParameterIndex++] =
+                    new OwlButton(fPatch, fButton, zone, label);
+            }
+        }
+        fButton = NO_BUTTON; // clear current button ID
     }
-    fButton = NO_BUTTON; 		// clear current button ID
-  }
 
-  // we dont want to create a widget but we clear the current parameter ID just in case
-  void skip() {
-    fParameter = NO_PARAMETER; 		// clear current parameter ID
-    fButton = NO_BUTTON;
-  }
+    // we dont want to create a widget but we clear the current parameter ID just in case
+    void skip() {
+        fParameter = NO_PARAMETER; // clear current parameter ID
+        fButton = NO_BUTTON;
+    }
 
 public:
-  MetaData meta;
-  OwlUI(Patch* pp) : fPatch(pp), fParameter(NO_PARAMETER), fParameterIndex(0), fButton(NO_BUTTON) {}
-	
-  virtual ~OwlUI() {
-    for (int i=0; i<fParameterIndex; i++)
-      delete fParameterTable[i];
-}
-	
-  // should be called before compute() to update widget's zones registered as Owl parameters
-  void update() {
-    for (int i=0; i<fParameterIndex; i++)
-      fParameterTable[i]->update();
-  }
-
-  //---------------------- virtual methods called by buildUserInterface ----------------
-	
-  // -- widget's layouts
-
-  virtual void openTabBox(const char* label) {}
-  virtual void openHorizontalBox(const char* label) {}
-  virtual void openVerticalBox(const char* label) {}
-  virtual void closeBox() {}
-
-  // -- active widgets
-
-  virtual void addButton(const char* label, FAUSTFLOAT* zone) { addOwlButton(label, zone); }
-  virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) { addOwlButton(label, zone); }
-  virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) { addInputOwlParameter(label, zone, init, lo, hi); }
-  virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) { addInputOwlParameter(label, zone, init, lo, hi); }
-  virtual void addNumEntry(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) { addInputOwlParameter(label, zone, init, lo, hi); }
-
-  // -- passive widgets
-
-  virtual void addHorizontalBargraph(const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi)	{ addOutputOwlParameter(label, zone, lo, hi); }
-  virtual void addVerticalBargraph  (const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi) { addOutputOwlParameter(label, zone, lo, hi); }
-  // -- soundfiles
-  virtual void addSoundfile(const char* label, const char* filename, Soundfile** sf_zone) { skip(); }
-
-  // -- metadata declarations
-
-  virtual void declare(FAUSTFLOAT* z, const char* k, const char* id) {
-    if(strcasecmp(k,"OWL") == 0){
-      if(strncasecmp(id, "PARAMETER_", 10) == 0)
-	id += 10;
-      if (strcasecmp(id,"A") == 0)  fParameter = PARAMETER_A;
-      else if (strcasecmp(id,"B") == 0)  fParameter = PARAMETER_B;
-      else if (strcasecmp(id,"C") == 0)  fParameter = PARAMETER_C;
-      else if (strcasecmp(id,"D") == 0)  fParameter = PARAMETER_D;
-      else if (strcasecmp(id,"E") == 0)  fParameter = PARAMETER_E;
-      else if (strcasecmp(id,"F") == 0)  fParameter = PARAMETER_F;
-      else if (strcasecmp(id,"G") == 0)  fParameter = PARAMETER_G;
-      else if (strcasecmp(id,"H") == 0)  fParameter = PARAMETER_H;
-      else if (strcasecmp(id,"PUSH") == 0)  fButton = PUSHBUTTON;
-      else if (strcasecmp(id,"ButtonA") == 0)  fButton = BUTTON_A;
-      else if (strcasecmp(id,"ButtonB") == 0)  fButton = BUTTON_B;
-      else if (strcasecmp(id,"ButtonC") == 0)  fButton = BUTTON_C;
-      else if (strcasecmp(id,"ButtonD") == 0)  fButton = BUTTON_D;
-    }else if(strcasecmp(k,"midi") == 0){
-      // todo!
-      // if (strcasecmp(id,"pitchwheel") == 0)  fParameter = PARAMETER_G; // mapped to pitch wheel
-      // declare(&fHslider1, "midi", "pitchwheel");
-      // declare(&fButton1, "midi", "ctrl 64");
+    MetaData meta;
+    OwlUI(Patch* pp)
+        : fPatch(pp)
+        , fParameter(NO_PARAMETER)
+        , fParameterIndex(0)
+        , fButton(NO_BUTTON) {
     }
 
-  }
+    virtual ~OwlUI() {
+        for (int i = 0; i < fParameterIndex; i++)
+            delete fParameterTable[i];
+        if (meta.vOctInput)
+            delete fVOctInput;
+        if (meta.vOctOutput)
+            delete fVOctOutput;
+    }
+
+    // should be called before compute() to update widget's zones registered as Owl parameters
+    void update() {
+        for (int i = 0; i < fParameterIndex; i++)
+            fParameterTable[i]->update();
+    }
+
+    //---------------------- virtual methods called by buildUserInterface ----------------
+
+    // -- widget's layouts
+
+    virtual void openTabBox(const char* label) {
+    }
+    virtual void openHorizontalBox(const char* label) {
+    }
+    virtual void openVerticalBox(const char* label) {
+    }
+    virtual void closeBox() {
+    }
+
+    // -- active widgets
+
+    virtual void addButton(const char* label, FAUSTFLOAT* zone) {
+        addOwlButton(label, zone);
+    }
+    virtual void addCheckButton(const char* label, FAUSTFLOAT* zone) {
+        addOwlButton(label, zone);
+    }
+    virtual void addVerticalSlider(const char* label, FAUSTFLOAT* zone,
+        FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) {
+        addInputOwlParameter(label, zone, init, lo, hi);
+    }
+    virtual void addHorizontalSlider(const char* label, FAUSTFLOAT* zone,
+        FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) {
+        addInputOwlParameter(label, zone, init, lo, hi);
+    }
+    virtual void addNumEntry(const char* label, FAUSTFLOAT* zone,
+        FAUSTFLOAT init, FAUSTFLOAT lo, FAUSTFLOAT hi, FAUSTFLOAT step) {
+        addInputOwlParameter(label, zone, init, lo, hi);
+    }
+
+    // -- passive widgets
+
+    virtual void addHorizontalBargraph(
+        const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi) {
+        addOutputOwlParameter(label, zone, lo, hi);
+    }
+    virtual void addVerticalBargraph(
+        const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi) {
+        addOutputOwlParameter(label, zone, lo, hi);
+    }
+    // -- soundfiles
+    virtual void addSoundfile(
+        const char* label, const char* filename, Soundfile** sf_zone) {
+        skip();
+    }
+
+    // -- metadata declarations
+
+    virtual void declare(FAUSTFLOAT* z, const char* k, const char* id) {
+        if (strcasecmp(k, "OWL") == 0) {
+            if (strncasecmp(id, "PARAMETER_", 10) == 0)
+                id += 10;
+
+            if (strlen(id) == 1) {
+                // Single char parameter name.
+                // Note that we can use I - P as aliases for AA-AH.
+                // Rationale: Magus uses only single letters param names, has
+                // no free space on display for second letter.
+                if (*id >= 'A' && *id <= 'P') {
+                    // Uppercase parameter name
+                    fParameter = PatchParameterId(*id - 'A');
+                }
+                else if (*id >= '0' && *id <= '9') {
+                    // Parameter can be numeric as well
+                    fParameter = PatchParameterId(*id - '0');
+                }
+                else if (*id >= 'a' && *id <= 'P') {
+                    // Lowercase parameter name
+                    fParameter = PatchParameterId(*id - 'a');
+                }
+            }
+            else if (strlen(id) == 2) {
+                int param_tmp = -1;
+                bool is_digit = false;
+                if (*id >= 'A' && *id <= 'D') {
+                    // Uppercase parameter name
+                    param_tmp = *id - 'A';
+                }
+                else if (*id >= '0' && *id <= '9') {
+                    // Parameter can be numeric as well
+                    is_digit = true;
+                    fParameter = PatchParameterId(*id - '0');
+                }
+                else if (*id >= 'a' && *id <= 'd') {
+                    // Lowercase parameter name
+                    param_tmp = *id - 'a';
+                }
+                if (param_tmp != -1) {
+                    id++;
+                    if (is_digit) {
+                        // Get second digit for decimal param
+                        param_tmp *= 10;
+                        if (*id >= '0' && *id <= '9') {
+                            fParameter = PatchParameterId(
+                                std::min(int(PARAMETER_DH), param_tmp + *id - '0'));
+                        }
+                    }
+                    else {
+                        // Inc to skip 1-character params
+                        param_tmp++;
+                        // This is first character for groups of 8 params
+                        param_tmp *= 8;
+                        // Second char for parameter name
+                        if (*id >= 'A' && *id <= 'H') {
+                            // Uppercase parameter name
+                            fParameter = PatchParameterId(param_tmp + *id - 'A');
+                        }
+                        else if (*id >= 'a' && *id <= 'h') {
+                            // Lowercase parameter name
+                            fParameter = PatchParameterId(param_tmp + *id - 'a');
+                        }
+                    }
+                }
+            }
+            else if (strcasecmp(id, "PUSH") == 0)
+                fButton = PUSHBUTTON;
+            else if (strcasecmp(id, "ButtonA") == 0)
+                fButton = BUTTON_A;
+            else if (strcasecmp(id, "ButtonB") == 0)
+                fButton = BUTTON_B;
+            else if (strcasecmp(id, "ButtonC") == 0)
+                fButton = BUTTON_C;
+            else if (strcasecmp(id, "ButtonD") == 0)
+                fButton = BUTTON_D;
+        }
+        else if (strcasecmp(k, "midi") == 0) {
+            // todo!
+            // if (strcasecmp(id,"pitchwheel") == 0)  fParameter = PARAMETER_G;
+            // // mapped to pitch wheel declare(&fHslider1, "midi",
+            // "pitchwheel"); declare(&fButton1, "midi", "ctrl 64");
+        }
+    }
+
+    // -- V/Oct
+
+    void addVOct() {
+        if (meta.vOctInput)
+            fVOctInput = new VoltsPerOctave(true);
+        if (meta.vOctOutput)
+            fVOctOutput = new VoltsPerOctave(false);
+    }
 };
 
 /* Simple heap based memory manager.
  * Uses overloaded new/delete operators on OWL hardware.
  */
 struct OwlMemoryManager : public dsp_memory_manager {
-  void* allocate(size_t size)
-  {
-    void* res = new uint8_t[size];
-    return res;
-  }
-  virtual void destroy(void* ptr)
-  {
-    delete (uint8_t*)ptr;
-  }    
+    void* allocate(size_t size) {
+        void* res = new uint8_t[size];
+        return res;
+    }
+    virtual void destroy(void* ptr) {
+        delete (uint8_t*)ptr;
+    }
 };
 
 #endif // __FaustCommonInfrastructure__
 
 /**************************BEGIN USER SECTION **************************/
 
-<<includeIntrinsic>>
+<< includeIntrinsic >>
 
-<<includeclass>>
+    << includeclass >>
 
-/***************************END USER SECTION ***************************/
+    /***************************END USER SECTION ***************************/
 
-/*******************BEGIN ARCHITECTURE SECTION (part 2/2)***************/
+    /*******************BEGIN ARCHITECTURE SECTION (part 2/2)***************/
 
+    /**************************************************************************************
 
+        FaustPatch : an OWL patch that calls Faust generated DSP code
 
-/**************************************************************************************
+    ***************************************************************************************/
 
-	FaustPatch : an OWL patch that calls Faust generated DSP code
-	
-***************************************************************************************/
+    class FaustPatch : public Patch {
+    mydsp* fDSP;
+    OwlUI fUI;
+    OwlMemoryManager mem;
 
-class FaustPatch : public Patch
-{
-  mydsp*   fDSP;
-  OwlUI	fUI;
-  OwlMemoryManager mem;
-    
 public:
+    FaustPatch()
+        : fUI(this) {
+        // // Allocate memory for dsp object first to ensure high priority
+        // memory is used void* allocated = mem.allocate(sizeof(mydsp));
+        // // DSP static data is initialised using classInit.
+        // mydsp::classInit(int(getSampleRate()), &mem);
+        // // call mydsp constructor
+        // fDSP = new (allocated) mydsp();
+        // fDSP->instanceInit(int(getSampleRate()));
+        // // Map OWL parameters and faust widgets
+        // fDSP->buildUserInterface(&fUI);
 
-  FaustPatch() : fUI(this)
-  {
-    // // Allocate memory for dsp object first to ensure high priority memory is used
-    // void* allocated = mem.allocate(sizeof(mydsp));
-    // // DSP static data is initialised using classInit.
-    // mydsp::classInit(int(getSampleRate()), &mem);
-    // // call mydsp constructor
-    // fDSP = new (allocated) mydsp();
-    // fDSP->instanceInit(int(getSampleRate()));
-    // // Map OWL parameters and faust widgets 
-    // fDSP->buildUserInterface(&fUI);
+        fBend = 1.0f;
+        fDSP = new mydsp();
+        fDSP->metadata(&fUI.meta);
+        if (fUI.meta.message != NULL)
+            debugMessage(fUI.meta.message);
+        fUI.addVOct();
 
-    fBend = 1.0f;
-    fDSP = new mydsp();
-    fDSP->metadata(&fUI.meta);
-    if (fUI.meta.message != NULL)
-      debugMessage(fUI.meta.message);
-    mydsp::fManager = &mem; // set custom memory manager
-    mydsp::classInit(int(getSampleRate())); // initialise static tables
-    fDSP->instanceInit(int(getSampleRate())); // initialise DSP instance
-    fDSP->buildUserInterface(&fUI); // Map OWL parameters
-  }
-
-  ~FaustPatch(){
-    delete fDSP;
-    // mem.destroy(fDSP);
-    // DSP static data is destroyed using classDestroy.
-    mydsp::classDestroy();
-  }
-
-  void processMidi(MidiMessage msg){
-    if (fUI.meta.midiOn)
-      allocator.processMidi(msg);
-  }
-
-  void processAudio(AudioBuffer &buffer)
-  {
-    // Reasonably assume we will not have more than 32 channels
-    float*  ins[32];
-    float*  outs[32];
-    int     n = buffer.getChannels();
-        
-    if ( (fDSP->getNumInputs() < 32) && (fDSP->getNumOutputs() < 32) ) {
-            
-      // create the table of input channels
-      for(int ch=0; ch<fDSP->getNumInputs(); ++ch) {
-	ins[ch] = buffer.getSamples(ch%n);
-      }
-            
-      // create the table of output channels
-      for(int ch=0; ch<fDSP->getNumOutputs(); ++ch) {
-	outs[ch] = buffer.getSamples(ch%n);
-      }
-            
-      // read OWL parameters and updates corresponding Faust Widgets zones
-      fUI.update(); 
-            
-      // Process the audio samples
-      fDSP->compute(buffer.getSize(), ins, outs);
+        mydsp::fManager = &mem; // set custom memory manager
+        mydsp::classInit(int(getSampleRate())); // initialise static tables
+        fDSP->instanceInit(int(getSampleRate())); // initialise DSP instance
+        fDSP->buildUserInterface(&fUI); // Map OWL parameters
     }
-  }
+
+    ~FaustPatch() {
+        delete fDSP;
+        // mem.destroy(fDSP);
+        // DSP static data is destroyed using classDestroy.
+        mydsp::classDestroy();
+    }
+
+    void processMidi(MidiMessage msg) {
+        if (fUI.meta.midiOn)
+            allocator.processMidi(msg);
+    }
+
+    void processAudio(AudioBuffer& buffer) {
+        // Reasonably assume we will not have more than 32 channels
+        float* ins[32];
+        float* outs[32];
+        int n = buffer.getChannels();
+
+        if ((fDSP->getNumInputs() < 32) && (fDSP->getNumOutputs() < 32)) {
+            // create the table of input channels
+            for (int ch = 0; ch < fDSP->getNumInputs(); ++ch) {
+                ins[ch] = buffer.getSamples(ch % n);
+            }
+
+            // create the table of output channels
+            for (int ch = 0; ch < fDSP->getNumOutputs(); ++ch) {
+                outs[ch] = buffer.getSamples(ch % n);
+            }
+
+            // read OWL parameters and updates corresponding Faust Widgets zones
+            fUI.update();
+
+            // Process the audio samples
+            fDSP->compute(buffer.getSize(), ins, outs);
+        }
+    }
 };
 
 extern "C" {
-  void doSetButton(uint8_t id, uint16_t state, uint16_t samples);
-  int owl_pushbutton(int value){
+void doSetButton(uint8_t id, uint16_t state, uint16_t samples);
+
+int owl_pushbutton(int value) {
     static bool state = 0;
     static uint16_t counter = 0;
     value = (bool)value;
-    if(state != value){
-      state = value;
-      doSetButton(PUSHBUTTON, state, counter);
+    if (state != value) {
+        state = value;
+        doSetButton(PUSHBUTTON, state, counter);
     }
-    if(++counter > getProgramVector()->audio_blocksize)
-      counter = 0;
+    if (++counter > getProgramVector()->audio_blocksize)
+        counter = 0;
     return value;
-  }
+}
+
+// Uses input scaler and tuning
+float sample2hertz(float tune, float sample) {
+    fVOctInput->setTune(tune);
+    return fVOctInput->getFrequency(sample);
+}
+// Uses output scaler and tuning
+float hertz2sample(float tune, float hertz) {
+    fVOctOutput->setTune(tune);
+    return fVOctOutput->getSample(hertz);
+}
+// Uses input scaler
+float sample2volts(float sample) {
+    return fVOctInput->sampleToVolts(sample);
+}
+// No scaler required
+float volts2hertz(float volts) {
+    return VoltsPerOctave::voltsToHertz(volts);
+}
+// Uses output scaler
+float volts2sample(float volts) {
+    return fVOctOutput->voltsToSample(volts);
+}
+// No scaler required
+float hertz2volts(float hertz) {
+    return VoltsPerOctave::hertzToVolts(hertz);
+}
 }
 
 #endif // __FaustPatch_h__
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/FaustCode/owl.h
+++ b/FaustCode/owl.h
@@ -3,13 +3,36 @@
 
 /* In this file we declare all OWL foreign functions.
  * They can be used in a FAUST patch like this:
- * push = ffunction(int owl_pushbutton(int), <owl.h>,"");
+ * 
+ * pushbutton = ffunction(int owl_pushbutton(int), <owl.h>,"");
+ * 
+ * sample2hertz = ffunction(float sample2hertz(float, float), <owl.h>, "");
+ * 
+ * hertz2sample = ffunction(float, hertz2sample(float, float), <owl.h>, "");
+ * 
+ * sample2volts = ffunction(float sample2volts(float), <owl.h>, "");
+ * 
+ * volts2hertz = ffunction(float volts2hertz(float), <owl.h>, "");
+ * 
+ * volts2sample = ffunction(float volts2sample(float), <owl.h>, "");
+ * 
+ * hertz2volts = ffunction(float hertz2volts(float), <owl.h>, "");
+ * 
+ * Or you can just call import("owl.lib"); in your patch and use definitions
+ * from that file.
  */
+
 #ifdef __cplusplus
  extern "C" {
 #endif
 
    int owl_pushbutton(int value);
+   float sample2hertz(float tune, float sample);
+   float hertz2sample(float tune, float hertz);
+   float sample2volts(float sample);
+   float volts2hertz(float volts);
+   float volts2sample(float volts);
+   float hertz2volts(float hertz);
 
 #ifdef __cplusplus
 }

--- a/FaustCode/owl.lib
+++ b/FaustCode/owl.lib
@@ -1,0 +1,57 @@
+//------------------------ pushbutton ----------------
+// Send a gate signal to push button
+//
+// ### Usage:
+//    `_:pushbutton`
+//
+pushbutton = ffunction(int owl_pushbutton(int), <owl.h>, "");
+
+//------------------------ Voltage convertion ----------------
+
+//------------------------ sample2hertz ----------------------
+// Convert input sample to frequency in Hertz
+//
+// ### Usage:
+//    `_:sample2hertz(tune):_`
+//
+sample2hertz = ffunction(float sample2hertz(float, float), <owl.h>, "");
+
+//------------------------ hertz2sample ----------------------
+// Convert frequency in Hertz to output sample
+//
+// ### Usage:
+//    `_:hertz2sample(tune):_`
+//
+hertz2sample = ffunction(float hertz2sample(float, float), <owl.h>, "");
+
+//------------------------ sample2volts ----------------------
+// Convert input sample to Volts
+//
+// ### Usage:
+//    `_:sample2volts:_`
+//
+sample2volts = ffunction(float sample2volts(float), <owl.h>, "");
+
+//------------------------ volts2hertz -----------------------
+// Convert Volts into Hertz
+//
+// ### Usage:
+//    `_:volts2hertz:_`
+//
+volts2hertz = ffunction(float volts2hertz(float), <owl.h>, "");
+
+//------------------------ volts2sample ----------------------
+// Convert Volts into output sample
+//
+// ### Usage:
+//    `_:volts2sample:_`
+//
+volts2sample = ffunction(float volts2sample(float), <owl.h>, "");
+
+//------------------------ hertz2volts ----------------------
+// Convert Hertz into Volts
+//
+// ### Usage:
+//    `_:hertz2volts:_`
+//
+hertz2volts = ffunction(float hertz2volts(float), <owl.h>, "");

--- a/LibSource/VoltsPerOctave.cpp
+++ b/LibSource/VoltsPerOctave.cpp
@@ -36,15 +36,43 @@ VoltsPerOctave::VoltsPerOctave(bool input) : tune(0.0) {
 
 void VoltsPerOctave::getFrequency(FloatArray samples, FloatArray output){
   ASSERT(output.getSize() >= samples.getSize(), "Output buffer too short");
-  // todo: block based implementation
-  // samples.subtract(offset, output);
-  // samples.multiply(multiplier, output);
-  // for(int i=0; i<samples.getSize(); ++i)
-  //   output[i] = voltsToHertz(output[i]);
+  // Block based implementation - this is giving ~1% higher CPU usage, tested on Magus
+  /*
+  output.copyFrom(samples);
+  output.subtract(offset);
+  output.multiply(multiplier);
+  output.add(tune);
+  for(size_t i = 0; i < samples.getSize(); ++i)
+    output[i] = exp2f(output[i]);
+  output.multiply(440.f);
+  */
+
+  // Sample by sample processing
   for(size_t i=0; i<samples.getSize(); ++i)
-    output[i] = getFrequency(samples[i]);
+     output[i] = getFrequency(samples[i]);
 }
 
 void VoltsPerOctave::getFrequency(FloatArray samples){
   getFrequency(samples, samples);
+}
+
+void VoltsPerOctave::getSample(FloatArray frequencies, FloatArray output){
+  ASSERT(output.getSize() >= frequencies.getSize(), "Output buffer too short");
+  // Block based implementation - this gives the same CPU load as sample
+  // by sample processing, so probably no reason to use it
+  /*
+  for (size_t i = 0; i < output.getSize(); i++)
+    //output[i] = tune - hertzToVolts(output[i]);
+    output[i] = log2f(output[i]);
+  output.add(tune - log2f(440.0f));
+  output.multiply(1.0f / multiplier);
+  output.add(offset);
+  */
+  
+  // Sample by sample processing
+  for(size_t i=0; i < frequencies.getSize(); ++i)
+    output[i] = getSample(frequencies[i]);
+}
+void VoltsPerOctave::getSample(FloatArray frequencies){
+  getSample(frequencies, frequencies);
 }

--- a/LibSource/VoltsPerOctave.h
+++ b/LibSource/VoltsPerOctave.h
@@ -22,22 +22,27 @@ public:
     tune = octaves;
   }
   float getFrequency(float sample){
-    return voltsToHertz(sampleToVolts(sample)+tune);
+    return voltsToHertz(sampleToVolts(sample) + tune);
+  }
+  float getSample(float frequency){
+    return voltsToSample(hertzToVolts(frequency) + tune);
   }
   float sampleToVolts(float sample){
     return (sample-offset) * multiplier;
   }
-  float voltsToHertz(float volts){
+  static float voltsToHertz(float volts){
     return 440.f * exp2f(volts);
   }
   float voltsToSample(float volts){
     return volts / multiplier + offset;
   }
-  float hertzToVolts(float hertz){
+  static float hertzToVolts(float hertz){
     return log2f(hertz/440.0f);
   }
   void getFrequency(FloatArray samples, FloatArray output);
   void getFrequency(FloatArray samples);
+  void getSample(FloatArray frequencies, FloatArray output);
+  void getSample(FloatArray frequencies);
 };
 
 #endif /* __VoltsPerOctave_hpp__ */

--- a/Source/faustmath.h
+++ b/Source/faustmath.h
@@ -11,6 +11,7 @@
 
 // Float versions
 
+#define fast_fabsf(x) abs(x) 
 #define fast_acosf(x) acosf(x)
 #define fast_asinf(x) asinf(x)
 #define fast_atanf(x) atanf(x)
@@ -27,6 +28,7 @@
 // fast_log10f is defined in basicmath.h
 // fast_powf is defined in basicmath.h
 #define fast_remainderf(x, y) remainderf(x, y)
+#define fast_rintf(x) rintf(x)
 #define fast_roundf(x) roundf(x)
 #define fast_sinf(x) sinf(x) // Optimized for ARM
 #define fast_sqrtf(x) sqrtf(x) // Optimized for ARM
@@ -35,6 +37,7 @@
 // Double versions
 
 // Actually, we'll end up calling float versions and casting them to doubles.
+#define fast_fabs(x) abs(x)
 #define fast_acos(x) fast_acosf(x)
 #define fast_asin(x) fast_asinf(x)
 #define fast_atan(x) fast_atanf(x)
@@ -51,6 +54,7 @@
 #define fast_log10(x) fast_log10f(x)
 #define fast_pow(x, y) fast_powf(x, y)
 #define fast_remainder(x, y) fast_remainderf(x, y)
+#define fast_rint(x) fast_rintf(x)
 #define fast_round(x) fast_roundf(x)
 #define fast_sin(x) fast_sinf(x)
 #define fast_sqrt(x) fast_sqrtf(x)


### PR DESCRIPTION
Brief description for this update:

1. Added .clang-format file - I suggest to check it out if you're not familiar with this it, adjust format settings to your taste and then we can use it to have consistent beautiful source code. I've only used it on on Faust arch file.

2. Parameters list extended to support everything that MIDI implementation supports (A-H to DA-DH). Plus there are synonyms that match labels that Magus uses in (so I-P are used as aliases to DA-DH).

3. Added VOct input/output scaling support - objects are instantiated if its requested by patch metadata 

4. Added a small library with definitions of all foreign functions (pushbutton setting and VOct convertion)

5. VoltsPerOctave class has an extra family of functions - getSamples that mirrors getFrequency, just converts data in opposite way.

6. I've tested block-based processing in getSamples/getFrequency and it didn't give me any performance over per sample function calls, unfortunately

7. VoltsPerOctave class has several functions that don't use any class state (tuning or offset/multiplier) and perform calculation using only their inputs. I've changed them to be static as this way I can use them without instantiating objects.

8. Added a few functions to Faust's fastmath implementation that we use to prevent conflicts from template functions (and force optimized math). They've appeared in more recent versions of Faust.