### PR TITLE
Use optional flag for parameter inversion on legacy firmware

### DIFF
--- a/LibSource/Control.h
+++ b/LibSource/Control.h
@@ -13,17 +13,20 @@ public:
     set(value);
   }
   void set(const float value){
+#ifdef USE_LEGACY_FIRMWARE
     if(getProgramVector()->hardware_version == OWL_MODULAR_HARDWARE && PID < 4)
       doSetPatchParameter(PID, 4095 - (int16_t)(value*4096.0f));
     else
+#endif
       doSetPatchParameter(PID, (int16_t)(value*4096));
   }
   float get(){
-    if(getProgramVector()->hardware_version == OWL_MODULAR_HARDWARE && PID < 4){
+#ifdef USE_LEGACY_FIRMWARE
+    if(getProgramVector()->hardware_version == OWL_MODULAR_HARDWARE && PID < 4)
       return (4095 - getProgramVector()->parameters[PID])/4096.0f;
-    }else{
+    else
+#endif
       return getProgramVector()->parameters[PID]/4096.0f;
-    }
   }
   Control<PID>& operator=(const float value){
     set(value);

--- a/LibSource/Control.h
+++ b/LibSource/Control.h
@@ -14,7 +14,7 @@ public:
   }
   void set(const float value){
 #ifdef USE_LEGACY_FIRMWARE
-    if(getProgramVector()->hardware_version == OWL_MODULAR_HARDWARE && PID < 4)
+    if(getProgramVector()->isLegacyFirmware() && PID < 4)
       doSetPatchParameter(PID, 4095 - (int16_t)(value*4096.0f));
     else
 #endif
@@ -22,7 +22,7 @@ public:
   }
   float get(){
 #ifdef USE_LEGACY_FIRMWARE
-    if(getProgramVector()->hardware_version == OWL_MODULAR_HARDWARE && PID < 4)
+    if(getProgramVector()->isLegacyFirmware() && PID < 4)
       return (4095 - getProgramVector()->parameters[PID])/4096.0f;
     else
 #endif

--- a/LibSource/Patch.cpp
+++ b/LibSource/Patch.cpp
@@ -33,7 +33,7 @@ float Patch::getParameterValue(PatchParameterId pid){
   // if(pid < getProgramVector()->parameters_size)
   if(pid < getProgramVector()->parameters_size){
 #ifdef USE_LEGACY_FIRMWARE
-    if(getProgramVector()->hardware_version == OWL_MODULAR_HARDWARE && pid < 4)
+    if(getProgramVector()->isLegacyFirmware() && pid < 4)
       return (4095 - getProgramVector()->parameters[pid])/4096.0f;
     else
 #endif
@@ -44,7 +44,7 @@ float Patch::getParameterValue(PatchParameterId pid){
 
 void Patch::setParameterValue(PatchParameterId pid, float value){
 #ifdef USE_LEGACY_FIRMWARE
-  if(getProgramVector()->hardware_version == OWL_MODULAR_HARDWARE && pid < 4)
+  if(getProgramVector()->isLegacyFirmware() && pid < 4)
     doSetPatchParameter(pid, 4095 - (int16_t)(value*4096.0f));
   else
 #endif

--- a/LibSource/Patch.cpp
+++ b/LibSource/Patch.cpp
@@ -32,19 +32,22 @@ float Patch::getParameterValue(PatchParameterId pid){
   //  return getInitialisingPatchProcessor()->getParameterValue(pid);
   // if(pid < getProgramVector()->parameters_size)
   if(pid < getProgramVector()->parameters_size){
-    if(getProgramVector()->hardware_version == OWL_MODULAR_HARDWARE && pid < 4){
+#ifdef USE_LEGACY_FIRMWARE
+    if(getProgramVector()->hardware_version == OWL_MODULAR_HARDWARE && pid < 4)
       return (4095 - getProgramVector()->parameters[pid])/4096.0f;
-    }else{
+    else
+#endif
       return getProgramVector()->parameters[pid]/4096.0f;
-    }
   }
   return 0.0f;
 }
 
 void Patch::setParameterValue(PatchParameterId pid, float value){
+#ifdef USE_LEGACY_FIRMWARE
   if(getProgramVector()->hardware_version == OWL_MODULAR_HARDWARE && pid < 4)
     doSetPatchParameter(pid, 4095 - (int16_t)(value*4096.0f));
   else
+#endif
     doSetPatchParameter(pid, (int16_t)(value*4096));
 }
 
@@ -82,7 +85,7 @@ int Patch::getElapsedCycles(){
       screen.setTextSize(1);
       screen.setTextWrap(true);
       screen.print(0, 26, pv->message);
-    }    
+    }
   }
   void drawTitle(const char* title, ScreenBuffer& screen){
     // draw title

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifndef CONFIG
 endif
 
 ifndef PLATFORM
-  PLATFORM=OWL
+  PLATFORM=OwlLegacy
 endif
 
 DEPS = .FORCE

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Make sure to do a `make clean` before compiling a new patch, or add `clean` to y
 * PATCHOUT: number of output channels, default 2
 * SLOT: user program slot to store patch in, default 0
 * TARGET: changes the output prefix, default 'patch'
-* PLATFORM: Alchemist, Wizard, Prism, Magus, Player, default 'OWL'
+* PLATFORM: Alchemist, Wizard, Prism, Magus, Player, OWL, default 'OwlLegacy'
 
 If you follow the convention of SimpleDelay then you don't have to specify `PATCHCLASS` and `PATCHFILE`, they will be deduced from `PATCHNAME`.
 t

--- a/Source/PatchProcessor.cpp
+++ b/Source/PatchProcessor.cpp
@@ -48,15 +48,17 @@ AudioBuffer* PatchProcessor::createMemoryBuffer(int channels, int size){
 }
 
 void PatchProcessor::setParameterValues(int16_t *params){
+#ifdef USE_LEGACY_FIRMWARE
   if(getProgramVector()->hardware_version == OWL_MODULAR_HARDWARE){
     for(int i=0; i<4 && i<parameterCount; ++i)
       parameters[i]->update(4095 - params[i]);
     for(int i=4; i<parameterCount; ++i)
       parameters[i]->update(params[i]);
-  }else{
+  }
+  else
+#endif
     for(int i=0; i<parameterCount; ++i)
       parameters[i]->update(params[i]);
-  }
 }
 
 template<typename T, typename V>

--- a/Source/PatchProcessor.cpp
+++ b/Source/PatchProcessor.cpp
@@ -49,7 +49,7 @@ AudioBuffer* PatchProcessor::createMemoryBuffer(int channels, int size){
 
 void PatchProcessor::setParameterValues(int16_t *params){
 #ifdef USE_LEGACY_FIRMWARE
-  if(getProgramVector()->hardware_version == OWL_MODULAR_HARDWARE){
+  if(getProgramVector()->isLegacyFirmware()){
     for(int i=0; i<4 && i<parameterCount; ++i)
       parameters[i]->update(4095 - params[i]);
     for(int i=4; i<parameterCount; ++i)

--- a/Source/ProgramVector.h
+++ b/Source/ProgramVector.h
@@ -7,11 +7,22 @@
  extern "C" {
 #endif
 
-#define OWL_PEDAL_HARDWARE    0x11
-#define OWL_MODULAR_HARDWARE  0x12
-#define OWL_RACK_HARDWARE     0x13
-#define PRISM_HARDWARE        0x14
-#define PLAYER_HARDWARE       0x15
+#define OWL_PEDAL_HARDWARE          0x11
+#define OWL_MODULAR_LEGACY_HARDWARE 0x12
+#define OWL_RACK_HARDWARE           0x13
+#define PRISM_HARDWARE              0x14
+#define PLAYER_HARDWARE             0x15
+#define TESSERACT_HARDWARE          0x16
+#define ALCHEMIST_HARDWARE          0x17
+#define WIZARD_HARDWARE             0x18
+#define MAGUS_HARDWARE              0x19
+#define EFFECTSBOX_HARDWARE         0x1a
+#define WAVETABLE_HARDWARE          0x1b
+#define NOCTUA_HARDWARE             0x1c
+#define BIOSIGNALS_HARDWARE         0x1d
+#define LICH_HARDWARE               0x1e
+#define WITCH_HARDWARE              0x1f
+#define OWL_MODULAR_HARDWARE        0x20 /* This is not a new device, but a way to distinguish firmware */
 
 #define PROGRAM_VECTOR_CHECKSUM_V11 0x40
 #define PROGRAM_VECTOR_CHECKSUM_V12 0x50
@@ -62,6 +73,16 @@
      void (*setPatchParameter)(uint8_t id, int16_t value);
      void (*buttonChangedCallback)(uint8_t bid, uint16_t state, uint16_t samples);
      MemorySegment* heapLocations;
+#ifdef USE_LEGACY_FIRMWARE
+     /*
+      * This function is currently used to determine if it's necessary to handle inverting
+      * ADC values. This is only required for running under legacy firmware (OwlWare) on
+      * Owl Modular.
+      */
+     inline bool isLegacyFirmware() const {
+       return hardware_version == OWL_MODULAR_LEGACY_HARDWARE;
+     }
+#endif
    } ProgramVector;
 
 #define CHECKSUM_ERROR_STATUS      -10

--- a/compile.mk
+++ b/compile.mk
@@ -66,6 +66,8 @@ CPP_SRC     += ScreenBuffer.cpp ScreenBufferDevice.cpp
 else ifeq ($(PLATFORM),Player)
 CPPFLAGS    += -DOWL_PLAYER
 CPP_SRC     += ScreenBuffer.cpp ScreenBufferDevice.cpp
+else ifeq ($(PLATFORM),OwlLegacy)
+CPPFLAGS    += -DOWL_CLASSIC -DUSE_LEGACY_FIRMWARE
 else
 CPPFLAGS    += -DOWL_CLASSIC
 endif


### PR DESCRIPTION
This removes parameter inversion from OWL builds unless "USE_LEGACY_FIRMWARE" flag is set. Not sure if we should define it by default or no, especially for web patcher.