### PR TITLE
Faust param fixes

### DIFF
--- a/FaustCode/owl.cpp
+++ b/FaustCode/owl.cpp
@@ -414,14 +414,14 @@ class OwlUI : public UI {
             else if (fParameter != NO_PARAMETER) {
                 fParameterTable[fParameterIndex++] = new OwlParameter(
                     fPatch, fParameter, zone, label, lo, lo, hi, true);
-	    }
-	    else if(fButton != NO_BUTTON){
-	        fParameterTable[fParameterIndex++] = new OwlButton(
-		    fPatch, fButton, zone, label, true);
-	    }
-	}
-	fParameter = NO_PARAMETER;
-	fButton = NO_BUTTON;
+            }
+            else if(fButton != NO_BUTTON){
+                fParameterTable[fParameterIndex++] = new OwlButton(
+                fPatch, fButton, zone, label, true);
+            }
+        }
+        fParameter = NO_PARAMETER;
+        fButton = NO_BUTTON;
     }
 
     void addOwlButton(const char* label, FAUSTFLOAT* zone) {
@@ -435,7 +435,7 @@ class OwlUI : public UI {
                     new OwlButton(fPatch, fButton, zone, label);
             }
         }
-	fParameter = NO_PARAMETER;
+        fParameter = NO_PARAMETER;
         fButton = NO_BUTTON; // clear current button ID
     }
 
@@ -572,8 +572,8 @@ public:
                     }
                     else if (param_tmp == PARAMETER_B && *id >= '0' && *id <= '9') {
                         fButton = PatchButtonId(BUTTON_A + *id - '1');
-		    }
-		    else {
+                    }
+                    else {
                         // Inc to skip 1-character params
                         param_tmp++;
                         // This is first character for groups of 8 params

--- a/FaustCode/owl.cpp
+++ b/FaustCode/owl.cpp
@@ -396,8 +396,8 @@ class OwlUI : public UI {
 
     void addOutputOwlParameter(
         const char* label, FAUSTFLOAT* zone, FAUSTFLOAT lo, FAUSTFLOAT hi) {
-        if(label[strlen(label) - 1] == '>')
-  	    debugMessage("Add '>' character for output parameters");
+        if(label[strlen(label) - 1] != '>')
+            debugMessage("Add '>' character for output parameters");
         if (fParameterIndex < MAXOWLPARAMETERS) {
             if (meta.midiOn && strcasecmp(label, "freq") == 0) {
                 fParameterTable[fParameterIndex++] =


### PR DESCRIPTION
Last update for Faust template had a bonus bug introduced when assert was replaced by debugMessage - it started to check opposite of what it was supposed to. Which means that it warned you every time you had ">" as last symbol of output param label.

Confirmed that output to buttons works, so I'll be adding an example of this to Faust docs.

And yes, tabs.