### PR TITLE
Delete object files too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ clean: ## remove generated patch files
 	@rm -rf $(BUILD)/*
 
 realclean: clean ## remove all library object files
-	@find Libraries/ -name '*.a' -delete
+	@find Libraries/ -name '*.[a|o]' -delete
 
 size: patch ## show binary size metrics and large object summary
 	@$(MAKE) -s -f common.mk size


### PR DESCRIPTION
Confirmed that this syntax worked, i.e.

```
find Libraries/ -name '*.[a|o]' -print 
Libraries/libowlprg.a
Libraries/CMSIS/DSP_Lib/Source/StatisticsFunctions/arm_std_q15.o
Libraries/CMSIS/DSP_Lib/Source/StatisticsFunctions/arm_mean_q15.o
Libraries/CMSIS/DSP_Lib/Source/StatisticsFunctions/arm_power_f32.o
....
```