### PR TITLE
Soundfiles support

### DIFF
--- a/FaustCode/WaveReader.h
+++ b/FaustCode/WaveReader.h
@@ -1,0 +1,256 @@
+/************************** BEGIN WaveReader.h **************************/
+/************************************************************************
+ FAUST Architecture File
+ Copyright (C) 2020 GRAME, Centre National de Creation Musicale
+ ---------------------------------------------------------------------
+ This Architecture section is free software; you can redistribute it
+ and/or modify it under the terms of the GNU General Public License
+ as published by the Free Software Foundation; either version 3 of
+ the License, or (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; If not, see <http://www.gnu.org/licenses/>.
+ 
+ EXCEPTION : As a special exception, you may create a larger work
+ that contains this FAUST architecture section and distribute
+ that work under terms of your choice, so long as this FAUST
+ architecture section is not modified.
+ ************************************************************************/
+
+#ifndef __WaveReader__
+#define __WaveReader__
+
+#undef min
+#undef max
+
+#include <string>
+#include "Resource.h"
+
+// WAVE file description
+class WaveFile {
+public:
+    // The canonical WAVE format starts with the RIFF header
+    
+    /**
+     Variable: chunk_id
+     Contains the letters "RIFF" in ASCII form (0x52494646 big-endian form).
+     **/
+    int chunk_id;
+    
+    /**
+     Variable: chunk_size
+     36 + SubChunk2Size, or more precisely: 4 + (8 + SubChunk1Size) + (8 + SubChunk2Size)
+     This is the size of the rest of the chunk following this number.
+     This is the size of the entire file in bytes minus 8 bytes for the
+     two fields not included in this count: ChunkID and ChunkSize.
+     **/
+    int chunk_size;
+    
+    /**
+     Variable: format
+     Contains the letters "WAVE" (0x57415645 big-endian form).
+     **/
+    int format;
+    
+    // The "WAVE" format consists of two subchunks: "fmt " and "data":
+    // The "fmt " subchunk describes the sound data's format:
+    
+    /**
+     Variable: subchunk_1_id
+     Contains the letters "fmt " (0x666d7420 big-endian form).
+     **/
+    int subchunk_1_id;
+    
+    /**
+     Variable: subchunk_1_size
+     16 for PCM. This is the size of the rest of the Subchunk which follows this number.
+     **/
+    int subchunk_1_size;
+    
+    /**
+     Variable: audio_format
+     PCM = 1 (i.e. Linear quantization) Values other than 1 indicate some form of compression.
+     **/
+    short audio_format;
+    
+    /**
+     Variable: num_channels
+     Mono = 1, Stereo = 2, etc.
+     **/
+    short num_channels;
+    
+    /**
+     Variable: sample_rate
+     8000, 44100, etc.
+     **/
+    int sample_rate;
+    
+    /**
+     Variable: byte_rate
+     == SampleRate * NumChannels * BitsPerSample/8
+     **/
+    int byte_rate;
+    
+    /**
+     Variable: block_align
+     == NumChannels * BitsPerSample/8
+     The number of bytes for one sample including all channels. I wonder what happens
+     when this number isn't an integer?
+     **/
+    short block_align;
+    
+    /**
+     Variable: bits_per_sample
+     8 bits = 8, 16 bits = 16, etc.
+     **/
+    short bits_per_sample;
+    
+    /**
+     Here should come some extra parameters which i will avoid.
+     **/
+    
+    // The "data" subchunk contains the size of the data and the actual sound:
+    
+    /**
+     Variable: subchunk_2_id
+     Contains the letters "data" (0x64617461 big-endian form).
+     **/
+    int subchunk_2_id;
+    
+    /**
+     Variable: subchunk_2_size
+     == NumSamples * NumChannels * BitsPerSample/8
+     This is the number of bytes in the data. You can also think of this as the size
+     of the read of the subchunk following this number.
+     **/
+    int subchunk_2_size;
+    
+    /**
+     Variable: data
+     The actual sound data.
+     **/
+    char* data;
+    
+};
+
+// Base reader
+class WaveReader {
+public:    
+    WaveFile* fWave;
+
+    WaveReader() {
+        fWave = new WaveFile();
+    }
+
+    virtual ~WaveReader() {
+        if (fWave->data != NULL)
+            delete[] fWave->data;
+        delete fWave;
+    }
+
+    bool loadWaveHeader() {
+        char buffer[4];
+        
+        read(buffer, 4);
+        if (strncmp(buffer, "RIFF", 4) != 0) {
+            debugMessage("Not a valid WAV file!");
+            return false;
+        }
+
+        fWave->chunk_id = toInt(buffer, 4);
+        
+        read(buffer, 4);
+        fWave->chunk_size = toInt(buffer, 4);
+        
+        read(buffer, 4);
+        fWave->format = toInt(buffer, 4);
+        
+        read(buffer, 4);
+        fWave->subchunk_1_id = toInt(buffer, 4);
+        
+        read(buffer, 4);
+        fWave->subchunk_1_size = toInt(buffer, 4);
+        
+        read(buffer, 2);
+        fWave->audio_format = toInt(buffer, 2);
+        read(buffer, 2);
+        fWave->num_channels = toInt(buffer, 2);
+        
+        read(buffer, 4);
+        fWave->sample_rate = toInt(buffer, 4);
+        
+        read(buffer, 4);
+        fWave->byte_rate = toInt(buffer, 4);
+        
+        read(buffer, 2);
+        fWave->block_align = toInt(buffer, 2);
+        read(buffer, 2);
+        fWave->bits_per_sample = toInt(buffer, 2);
+        
+        read(buffer, 4);
+        if (strncmp(buffer, "data", 4) != 0) {
+            read(buffer, 4);
+            int _extra_size = toInt(buffer, 4);
+            char _extra_data[_extra_size];
+            read(_extra_data, _extra_size);
+            read(buffer, 4);
+            fWave->subchunk_2_id = toInt(buffer, 4);
+        } else {
+            fWave->subchunk_2_id = toInt(buffer, 4);
+        }
+        
+        read(buffer, 4);
+        fWave->subchunk_2_size = toInt(buffer, 4);
+        return true;
+    }
+    
+    void loadWave()
+    {
+        // Read sound data
+        fWave->data = new char[fWave->subchunk_2_size];
+        read(fWave->data, fWave->subchunk_2_size);
+    }
+
+    virtual void read(char* buffer, unsigned int size) = 0;
+
+protected:
+    inline int toInt(char* buffer, int len)
+    {
+        int a = 0;
+        for(int i = 0; i < len; i++) {
+            ((char*)&a)[i] = buffer[i];
+        }
+        return a;
+    }   
+};
+
+/*
+ * WAV file reader that handles resource parser
+ */
+class WaveResourceReader : public WaveReader {
+public:
+    WaveResourceReader(const char* name) :
+        offset(0) {
+        resource = Resource::open(name);
+    };
+
+    ~WaveResourceReader() {
+        Resource::destroy(resource);
+    };
+
+    void read(char* buffer, unsigned int size) override {
+        size_t read_len = resource->read((void*)buffer, size, offset);
+        offset += read_len;
+    }
+private:
+    Resource* resource;
+    size_t offset;
+};
+
+#endif
+/**************************  END  WaveReader.h **************************/

--- a/FaustCode/owl.cpp
+++ b/FaustCode/owl.cpp
@@ -577,7 +577,7 @@ class OwlUI : public UI {
     int fSampleRate;
     //std::map<std::string, Soundfile*> fSoundfileMap;    // Map to share loaded soundfiles
     OwlParameterBase* fParameterTable[MAXOWLPARAMETERS];
-    OwlResourceReader* fSoundReader;
+    OwlResourceReader* fSoundReader = NULL;
     Soundfile* fSoundfiles[MAX_SOUNDFILES];
     PatchButtonId fButton;
     // check if the widget is an Owl parameter and, if so, add the corresponding OwlParameter

--- a/FaustCode/owl.cpp
+++ b/FaustCode/owl.cpp
@@ -663,8 +663,6 @@ public:
         , fParameterIndex(0)
         , fSoundfileIndex(0)
         , fButton(NO_BUTTON) {
-        fSoundReader = new OwlResourceReader();
-        fSoundReader->setSampleRate(fPatch->getSampleRate());
     }
 
     virtual ~OwlUI() {

--- a/FaustCode/owl.cpp
+++ b/FaustCode/owl.cpp
@@ -38,11 +38,22 @@
 
 #include "Patch.h"
 #include "VoltsPerOctave.h"
+#include "Resource.h"
+#include "WaveReader.h"
 
 // We have to undefine min/max from OWL's basicmaths.h, otherwise they cause
 // errors when Faust calls functions with the same names in std:: namespace
 #undef min
 #undef max
+
+// Parent soundfile object uses exceptions in one of its method.
+// This is probably the easiest may to make GCC happy about it when we compile
+// with exceptions disabled.
+#define try if(true)
+#define catch(x) if(false)
+
+#define MAX_SOUNDFILES 32
+// This is just value for upper limit - actual memory used depends only on number of files loaded
 
 #include <string.h>
 #include <strings.h>
@@ -53,6 +64,8 @@
 #include "faust/dsp/dsp.h"
 #include "faust/gui/UI.h"
 #include "faust/gui/meta.h"
+#include "faust/gui/Soundfile.h"
+
 
 static float fKey, fFreq, fGain, fGate;
 static float fBend = 1.0f;
@@ -349,6 +362,194 @@ public:
 
 /**************************************************************************************
  *
+ * OwlResourceReader: Reads resources from flash storage and returns Soundfile objects.
+ *
+ * This is based on SoundfileReader in faust/gui/Soundfile.h with some changes:
+ * - no allocation of excessive amounts of RAM for empty buffers
+ * - no stdlib usage of vectors, maps,
+ * - exception handling removed
+ *
+ ***************************************************************************************/
+
+#define EMPTY_BUFFER_SIZE 0
+
+class OwlResourceReader {
+public:
+    virtual ~OwlResourceReader() {}
+
+    void setSampleRate(int sample_rate) { fDriverSR = sample_rate; }
+
+    Soundfile* createSoundfile(const char** path_name_list, int path_name_size, int max_chan) {
+        Soundfile *soundfile = NULL;
+        int cur_chan = 1; // At least one channel
+        int total_length = 1; // At least one byte - otherwise we can't allocate empty channels
+
+        // Compute total length and channels max of all files
+        for (int i = 0; i < path_name_size; i++) {
+            int chan, length;
+            if (strcmp(path_name_list[i], "__empty_sound__") == 0) {
+                length = EMPTY_BUFFER_SIZE;
+                chan = 1;
+            } else {
+                getParamsFile(path_name_list[i], chan, length);
+            }
+            cur_chan = std::max<int>(cur_chan, chan);
+            total_length += length;
+        }
+
+        // Complete with empty parts
+        total_length += (MAX_SOUNDFILE_PARTS - path_name_size) * EMPTY_BUFFER_SIZE;
+
+        // Create the soundfile
+        soundfile = createSoundfile(cur_chan, total_length, max_chan);
+
+        // Init offset
+        int offset = 0;
+
+        // Read all files
+        for (int i = 0; i < path_name_size; i++) {
+            if (strcmp(path_name_list[i], "__empty_sound__") == 0){
+                emptyFile(soundfile, i, offset);
+            } else {
+                readFile(soundfile, path_name_list[i], i, offset, max_chan);
+            }
+        }
+
+        // Complete with empty parts
+        for (int i = path_name_size; i < MAX_SOUNDFILE_PARTS; i++) {
+            emptyFile(soundfile, i, offset);
+        }
+
+        // Share the same buffers for all other channels so that we have max_chan channels available
+        for (int chan = cur_chan; chan < max_chan; chan++) {
+            soundfile->fBuffers[chan] = soundfile->fBuffers[chan % cur_chan];
+        }
+        return soundfile;
+    }
+
+    /**
+     * Check the availability of a sound resource.
+     *
+     * @param resource_name - the name of the file, or sound resource identified this way
+     *
+     * @return true if the sound resource is available, false otherwise.
+     */
+    bool checkFile(const char* resource_name) {
+        Resource* resource = Resource::open(resource_name);
+        bool result = resource != NULL;
+        Resource::destroy(resource);
+        if (!result){
+            debugMessage("Resource not found");
+        }
+        return result;
+    }
+
+protected:
+    int fDriverSR;
+
+    void emptyFile(Soundfile* soundfile, int part, int& offset) {
+        soundfile->fLength[part] = EMPTY_BUFFER_SIZE;
+        soundfile->fSR[part] = SAMPLE_RATE;
+        soundfile->fOffset[part] = offset;
+        // Update offset
+        offset += soundfile->fLength[part];
+    }
+
+    Soundfile* createSoundfile(int cur_chan, int length, int max_chan) {
+        Soundfile* soundfile = new Soundfile();
+        soundfile->fBuffers = new FAUSTFLOAT*[max_chan];
+
+        for (int chan = 0; chan < cur_chan; chan++) {
+            soundfile->fBuffers[chan] = new FAUSTFLOAT[length];
+            memset(soundfile->fBuffers[chan], 0, sizeof(FAUSTFLOAT) * length);
+        }
+
+        soundfile->fChannels = cur_chan;
+        return soundfile;
+    }
+
+    void getBuffersOffset(Soundfile* soundfile, FAUSTFLOAT** buffers, int offset) {
+        for (int chan = 0; chan < soundfile->fChannels; chan++) {
+            buffers[chan] = &soundfile->fBuffers[chan][offset];
+        }
+    }
+
+    /**
+     * Get the channels and length values of the given sound resource.
+     *
+     * @param path_name - the name of the file, or sound resource identified this way
+     * @param channels - the channels value to be filled with the sound resource number of channels
+     * @param length - the length value to be filled with the sound resource length in frames
+     *
+     */
+    void getParamsFile(const char* path_name, int& channels, int& length) {
+        WaveResourceReader reader(path_name);
+        channels = 1;
+        length = 0;
+
+        if (reader.loadWaveHeader()){
+            channels = reader.fWave->num_channels;
+            length = (reader.fWave->subchunk_2_size * 8) / (reader.fWave->num_channels * reader.fWave->bits_per_sample);
+        }
+    }
+
+    /**
+     * Read one sound resource and fill the 'soundfile' structure accordingly
+     *
+     * @param soundfile - the soundfile to be filled
+     * @param path_name - the name of the file, or sound resource identified this way
+     * @param part - the part number to be filled in the soundfile
+     * @param offset - the offset value to be incremented with the actual sound resource length in frames
+     * @param max_chan - the maximum number of mono channels to fill
+     *
+     */
+    void readFile(Soundfile* soundfile, const char* path_name, int part, int& offset, int max_chan) {
+        WaveResourceReader reader(path_name);
+        if (!reader.loadWaveHeader()){
+            return;
+        }
+        reader.loadWave();
+
+        soundfile->fLength[part] = (reader.fWave->subchunk_2_size * 8) / (reader.fWave->num_channels * reader.fWave->bits_per_sample);
+        soundfile->fSR[part] = reader.fWave->sample_rate;
+        soundfile->fOffset[part] = offset;
+
+        // Audio frames have to be written for each chan
+        switch (reader.fWave->bits_per_sample){
+        case 16:
+            // 16 bit samples are signed ints
+            for (int sample = 0; sample < soundfile->fLength[part]; sample++) {
+                float factor = 1.f/32767.f;
+                int16_t* frame = (int16_t*)&reader.fWave->data[reader.fWave->block_align * sample];
+                for (int chan = 0; chan < reader.fWave->num_channels; chan++) {
+                    soundfile->fBuffers[chan][offset + sample] = frame[chan] * factor;
+                }
+            }
+            break;
+        case 8:
+            // 8 bit samples are unsigned ints
+            for (int sample = 0; sample < soundfile->fLength[part]; sample++) {
+                float factor = 1.f/255.f;
+                uint8_t* frame = (uint8_t*)&reader.fWave->data[reader.fWave->block_align * sample];
+                for (int chan = 0; chan < reader.fWave->num_channels; chan++) {
+                    soundfile->fBuffers[chan][offset + sample] = frame[chan] * factor - 0.5f;
+                }
+            }
+            break;
+        default:
+            debugMessage("Unsupported format");
+            return;
+        }
+
+        //
+        // Update offset
+        offset += soundfile->fLength[part];
+    }
+};
+
+
+/**************************************************************************************
+ *
  * OwlUI : Faust User Interface builder. Passed to buildUserInterface OwlU
  * ensures the mapping between owl parameters and faust widgets. It relies on
  * specific metadata "...[OWL:PARAMETER_X]..." in widget's label for that. For
@@ -359,18 +560,25 @@ public:
 
 // The maximun number of mappings between owl parameters and faust widgets
 #define MAXOWLPARAMETERS 20
-#define NO_PARAMETER ((PatchParameterId)-1)
-#define NO_BUTTON ((PatchButtonId)-1)
+#define NO_PARAMETER     ((PatchParameterId)-1)
+#define NO_BUTTON        ((PatchButtonId)-1)
+#define PATH_LEN         24
 
 MonoVoiceAllocator allocator(fKey, fFreq, fGain, fGate, fBend);
 VoltsPerOctave* fVOctInput;
 VoltsPerOctave* fVOctOutput;
+Soundfile* defaultsound;
 
 class OwlUI : public UI {
     Patch* fPatch;
     PatchParameterId fParameter; // current parameter ID, value NO_PARAMETER means not set
-    int fParameterIndex = 0; // number of OwlParameters collected so far
+    int fParameterIndex;         // number of OwlParameters collected so far
+    int fSoundfileIndex;
+    int fSampleRate;
+    //std::map<std::string, Soundfile*> fSoundfileMap;    // Map to share loaded soundfiles
     OwlParameterBase* fParameterTable[MAXOWLPARAMETERS];
+    OwlResourceReader* fSoundReader;
+    Soundfile* fSoundfiles[MAX_SOUNDFILES];
     PatchButtonId fButton;
     // check if the widget is an Owl parameter and, if so, add the corresponding OwlParameter
     void addInputOwlParameter(const char* label, FAUSTFLOAT* zone,
@@ -398,7 +606,7 @@ class OwlUI : public UI {
             }
         }
         fParameter = NO_PARAMETER; // clear current parameter ID
-	fButton = NO_BUTTON;
+	    fButton = NO_BUTTON;
     }
 
     void addOutputOwlParameter(
@@ -434,10 +642,17 @@ class OwlUI : public UI {
         fButton = NO_BUTTON; // clear current button ID
     }
 
-    // we dont want to create a widget but we clear the current parameter ID just in case
-    void skip() {
-        fParameter = NO_PARAMETER; // clear current parameter ID
-        fButton = NO_BUTTON;
+    void addOwlResources(const char** resource_names, int names_size, Soundfile** sf_zone){
+        if (fSoundfileIndex < MAX_SOUNDFILES){
+            Soundfile* sound_file = fSoundReader->createSoundfile(resource_names, names_size, MAX_CHAN);
+            fSoundfiles[fSoundfileIndex++] = sound_file;
+            if (sound_file != NULL) {
+                *sf_zone = sound_file;
+                return;
+            }
+        }
+        // If failure, use 'defaultsound'
+        *sf_zone = defaultsound;
     }
 
 public:
@@ -446,7 +661,10 @@ public:
         : fPatch(pp)
         , fParameter(NO_PARAMETER)
         , fParameterIndex(0)
+        , fSoundfileIndex(0)
         , fButton(NO_BUTTON) {
+        fSoundReader = new OwlResourceReader();
+        fSoundReader->setSampleRate(fPatch->getSampleRate());
     }
 
     virtual ~OwlUI() {
@@ -456,6 +674,12 @@ public:
             delete fVOctInput;
         if (meta.vOctOutput)
             delete fVOctOutput;
+        if (fSoundReader != NULL) {
+            delete fSoundReader;
+        }
+        for (int i = 0; i < fSoundfileIndex; i++){
+            delete fSoundfiles[i];
+        }
     }
 
     // should be called before compute() to update widget's zones registered as OWL parameters
@@ -509,9 +733,58 @@ public:
         addOutputOwlParameter(label, zone, lo, hi);
     }
     // -- soundfiles
-    virtual void addSoundfile(
-        const char* label, const char* filename, Soundfile** sf_zone) {
-        skip();
+    virtual void addSoundfile(const char* label, const char* url, Soundfile** sf_zone) {
+        if (fSoundReader == NULL){
+            fSoundReader = new OwlResourceReader();
+            fSoundReader->setSampleRate(fPatch->getSampleRate());
+            defaultsound = fSoundReader->createSoundfile(nullptr, 0, 1);
+        }
+
+        if (url[0] == '{'){
+            char* paths[MAX_SOUNDFILE_PARTS];
+            int total_paths = 0;
+            bool reading_path = false;
+            const char* c = url;
+            const char* start_path;
+            while (c){
+                if (reading_path){
+                    if (*c++ == '\''){
+                        // Closing quote
+                        reading_path = false;
+                        uint32_t path_len = std::min<uint32_t>(c - start_path, PATH_LEN - 1);
+                        paths[total_paths] = new char[path_len];
+                        strncpy(paths[total_paths], start_path, path_len - 1);
+                        paths[total_paths][path_len -1] = 0;
+                        if (fSoundReader->checkFile(paths[total_paths]))
+                            total_paths++;
+                        else {
+                            delete[] paths[total_paths];
+                        }
+                    }
+                }
+                else {
+                    switch (*c){
+                    case '\'':
+                        // Opening quote
+                        start_path = ++c;
+                        reading_path = true;
+                        break;
+                    case '}':
+                        c = 0; // Done!
+                        break;
+                    default:
+                        // Path separator will end here
+                        c++;
+                        break;
+                    }
+                }
+            }
+            addOwlResources((const char**)paths, total_paths, sf_zone);
+            // Parsed path names are not used after loading resources
+            for (int i = 0; i < total_paths; i++){
+                delete[] paths[i];
+            }
+        }
     }
 
     // -- metadata declarations

--- a/faust.mk
+++ b/faust.mk
@@ -1,11 +1,12 @@
 FAUSTCC ?= faust
 FAUSTFLAGS ?= -light
+FAUSTCODE = FaustCode
 
 faust: $(BUILD)/Source/FaustPatch.hpp
 
 $(BUILD)/Source/FaustPatch.hpp: $(PATCHSOURCE)/$(FAUST).dsp
 	@$(FAUSTCC) $(FAUSTFLAGS) -I $(PATCHSOURCE) -i -inpl -mem -a FaustCode/owl.cpp -fm faustmath.h $< $(BUILDROOT)/FaustCode/owl.lib -o $@
-	@cp FaustCode/owl.h $(PATCHSOURCE)
+	@cp $(FAUSTCODE)/*.h $(BUILD)/Source/
 
 $(BUILD)/Source/%Patch.hpp: $(PATCHSOURCE)/%.dsp
 	@$(FAUSTCC) $(FAUSTFLAGS) -I $(PATCHSOURCE) -i -inpl -mem -a FaustCode/owl.cpp -fm faustmath.h $< -o $@


### PR DESCRIPTION
You must delete this unused include from current version of FAUST headers (iostream):

https://github.com/grame-cncm/faust/blob/master-dev/architecture/faust/gui/Soundfile.h#L28

I'll try to have it fixed upstream, because currently it makes compiler vomit something like this:

```
/home/antisvin/dev/rebeltech/OwlProgram.faust/Tools/gcc-arm-none-eabi-9-2020-q2-update/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: /tmp/patch.elf.6kL4sn.ltrans0.ltrans.o: in function `global constructors keyed to 65535_0_printf.o.9828':
<artificial>:(.text.startup+0x24): undefined reference to `std::ios_base::Init::Init()'
/home/antisvin/dev/rebeltech/OwlProgram.faust/Tools/gcc-arm-none-eabi-9-2020-q2-update/bin/../lib/gcc/arm-none-eabi/9.3.1/../../../../arm-none-eabi/bin/ld: <artificial>:(.text.startup+0xa8): undefined reference to `std::ios_base::Init::~Init()'
collect2: error: ld returned 1 exit status
make[1]: *** [compile.mk:140: Build/patch.elf] Error 1
make: *** [Makefile:111: patch] Error 2
```