### PR TITLE
Destroy audio buffers

### DIFF
--- a/LibSource/Patch.cpp
+++ b/LibSource/Patch.cpp
@@ -108,6 +108,10 @@ AudioBuffer* AudioBuffer::create(int channels, int samples){
   return new ManagedMemoryBuffer(channels, samples);
 }
 
+void AudioBuffer::destroy(AudioBuffer* buffer){
+  delete buffer;
+}
+
 FloatParameter Patch::getParameter(const char* name, float defaultValue){
   return getFloatParameter(name, 0.0f, 1.0f, defaultValue, 0.0f, 0.0f, LIN);
 }

--- a/LibSource/Patch.h
+++ b/LibSource/Patch.h
@@ -26,6 +26,7 @@ public:
   virtual int getSize() = 0;
   virtual void clear() = 0;
   static AudioBuffer* create(int channels, int samples);
+  static void destroy(AudioBuffer* buffer);
 };
 
 class Patch {


### PR DESCRIPTION
I've noticed that AudioBuffer has a create method, but not destroy. Previously it was utilized only for exchange with DMA buffers, but it's also used for multi-channel generators/processors now. So it's probably necessary to add something like this for completeness.

I haven't verified that it works yet, will do that in a day or two - making a few patches involving quadrature oscillators that would be allocating multichannel audio.