### PR TITLE
Quadrature oscillator and complex signals

### DIFF
--- a/LibSource/ComplexFloatArray.cpp
+++ b/LibSource/ComplexFloatArray.cpp
@@ -312,3 +312,20 @@ ComplexFloatArray ComplexFloatArray::create(size_t size){
 void ComplexFloatArray::destroy(ComplexFloatArray array){
   delete[] array.data;
 }
+
+void ComplexFloatArray::copyFrom(AudioBuffer& buffer) {
+  FloatArray left = buffer.getSamples(0);
+  FloatArray right = buffer.getSamples(1);
+  for (size_t i = 0; i < getSize(); i++) {
+    data[i] = ComplexFloat(left[i], right[i]);
+  }
+}
+
+void ComplexFloatArray::copyTo(AudioBuffer& buffer) {
+  FloatArray left = buffer.getSamples(0);
+  FloatArray right = buffer.getSamples(1);
+  for (size_t i = 0; i < getSize(); i++) {
+    left[i] = data[i].re;
+    right[i] = data[i].im;
+  }
+}

--- a/LibSource/ComplexFloatArray.cpp
+++ b/LibSource/ComplexFloatArray.cpp
@@ -313,19 +313,15 @@ void ComplexFloatArray::destroy(ComplexFloatArray array){
   delete[] array.data;
 }
 
-void ComplexFloatArray::copyFrom(AudioBuffer& buffer) {
-  FloatArray left = buffer.getSamples(0);
-  FloatArray right = buffer.getSamples(1);
+void ComplexFloatArray::copyFrom(FloatArray real, FloatArray imag) {
   for (size_t i = 0; i < getSize(); i++) {
-    data[i] = ComplexFloat(left[i], right[i]);
+    data[i] = ComplexFloat(real[i], imag[i]);
   }
 }
 
-void ComplexFloatArray::copyTo(AudioBuffer& buffer) {
-  FloatArray left = buffer.getSamples(0);
-  FloatArray right = buffer.getSamples(1);
+void ComplexFloatArray::copyTo(FloatArray real, FloatArray imag) {
   for (size_t i = 0; i < getSize(); i++) {
-    left[i] = data[i].re;
-    right[i] = data[i].im;
+    real[i] = data[i].re;
+    imag[i] = data[i].im;
   }
 }

--- a/LibSource/ComplexFloatArray.h
+++ b/LibSource/ComplexFloatArray.h
@@ -7,6 +7,10 @@
 * A structure defining a floating point complex number as two members of type float.
 */
 struct ComplexFloat {
+  constexpr ComplexFloat() : re(0), im(0) {}
+  constexpr ComplexFloat(float x) : re(x), im(0) {}
+  constexpr ComplexFloat(float re, float im) : re(re), im(im) {}
+
   /**
    * The real part of the complex number.
    */
@@ -75,27 +79,19 @@ struct ComplexFloat {
     im = magnitude*sinf(phase);
   }
 
-  float getMagnitudeSquared() {
-    return re * re + im * im;
-  }
-
-  ComplexFloat getComplexConjugate() {
+  /**
+   * Returns complet conjugate - a copy of current number with imaginary part inverted
+   */
+  ComplexFloat getComplexConjugate() const {
     return ComplexFloat {re, -im};
   }
 
-  ComplexFloat getDotProduct(ComplexFloat other) {
-    return ComplexFloat {re * other.re - im  * other.im, re * other.im + im * other.re};
-  }
 
   /**
-   * Copy assignment
+   * Returns dot product with another complex float value
    */
-  ComplexFloat& operator=(const ComplexFloat& other) {
-    if (this != &other) {
-      re = other.re;
-      im = other.im;
-    }
-    return *this;
+  ComplexFloat getDotProduct(ComplexFloat other) const {
+    return ComplexFloat {re * other.re - im  * other.im, re * other.im + im * other.re};
   }
 
   bool operator<(const ComplexFloat& other) const {

--- a/LibSource/ComplexFloatArray.h
+++ b/LibSource/ComplexFloatArray.h
@@ -75,6 +75,29 @@ struct ComplexFloat {
     im = magnitude*sinf(phase);
   }
 
+  float getMagnitudeSquared() {
+    return re * re + im * im;
+  }
+
+  ComplexFloat getComplexConjugate() {
+    return ComplexFloat {re, -im};
+  }
+
+  ComplexFloat getDotProduct(ComplexFloat other) {
+    return ComplexFloat {re * other.re - im  * other.im, re * other.im + im * other.re};
+  }
+
+  /**
+   * Copy assignment
+   */
+  ComplexFloat& operator=(const ComplexFloat& other) {
+    if (this != &other) {
+      re = other.re;
+      im = other.im;
+    }
+    return *this;
+  }
+
   bool operator<(const ComplexFloat& other) const {
     return getMagnitudeSquared() < other.getMagnitudeSquared();
   }
@@ -97,6 +120,90 @@ struct ComplexFloat {
   
   bool operator!=(const ComplexFloat& other) const {
     return re != other.re || im != other.im;
+  }
+
+  friend const ComplexFloat operator+(const ComplexFloat&lhs, const ComplexFloat& rhs) {
+    ComplexFloat result = lhs;
+    result += rhs;
+    return result;
+  }
+
+  friend const ComplexFloat operator+(const ComplexFloat&lhs, float rhs) {
+    ComplexFloat result = lhs;
+    result += rhs;
+    return result;
+  }
+
+  ComplexFloat& operator+=(float other) {
+    re += other;
+    im += other;
+    return *this;
+  }
+
+  ComplexFloat& operator+=(const ComplexFloat& other) {
+    re += other.re;
+    im += other.im;
+    return *this;
+  }
+
+  friend const ComplexFloat operator-(const ComplexFloat&lhs, const ComplexFloat& rhs) {
+    ComplexFloat result = lhs;
+    result -= rhs;
+    return result;
+  }
+
+  friend const ComplexFloat operator-(const ComplexFloat&lhs, float rhs) {
+    ComplexFloat result = lhs;
+    result -= rhs;
+    return result;
+  }
+
+  ComplexFloat& operator-=(float other) {
+    re -= other;
+    im -= other;
+    return *this;
+  }
+
+  ComplexFloat& operator-=(const ComplexFloat& other) {
+    re -= other.re;
+    im -= other.im;
+    return *this;
+  }
+
+  friend const ComplexFloat operator*(const ComplexFloat&lhs, const ComplexFloat& rhs) {
+    ComplexFloat result = lhs;
+    result *= rhs;
+    return result;
+  }
+
+  friend const ComplexFloat operator*(const ComplexFloat&lhs, float rhs) {
+    ComplexFloat result = lhs;
+    result *= rhs;
+    return result;
+  }
+
+  ComplexFloat& operator*=(float other) {
+    re *= other;
+    im *= other;
+    return *this;
+  }
+
+  ComplexFloat& operator*=(const ComplexFloat& other) {
+    re = re * other.re - im * other.im;
+    im = re * other.im + im * other.re;
+    return *this;
+  }
+
+  friend const ComplexFloat operator/(const ComplexFloat&lhs, float rhs) {
+    ComplexFloat result = lhs;
+    result /= rhs;
+    return result;
+  }
+
+  ComplexFloat& operator/=(float other) {
+    re /= other;
+    im /= other;
+    return *this;
   }
 
 };

--- a/LibSource/ComplexFloatArray.h
+++ b/LibSource/ComplexFloatArray.h
@@ -80,12 +80,11 @@ struct ComplexFloat {
   }
 
   /**
-   * Returns complet conjugate - a copy of current number with imaginary part inverted
+   * Returns complex conjugate - a copy of current number with imaginary part inverted
    */
   ComplexFloat getComplexConjugate() const {
     return ComplexFloat {re, -im};
   }
-
 
   /**
    * Returns dot product with another complex float value

--- a/LibSource/ComplexFloatArray.h
+++ b/LibSource/ComplexFloatArray.h
@@ -2,7 +2,9 @@
 #define __ComplexFloatArray_h__
 
 #include "FloatArray.h"
+#include "AudioBuffer.h"
 #include "basicmaths.h"
+
 /**
 * A structure defining a floating point complex number as two members of type float.
 */
@@ -498,6 +500,9 @@ public:
    * @param[out] destination The destination array.
   */
   void setMagnitude(FloatArray magnitude, int offset, size_t count, ComplexFloatArray destination);
+
+  void copyFrom(AudioBuffer& buffer);
+  void copyTo(AudioBuffer& buffer);
 };
 
 #endif // __ComplexFloatArray_h__

--- a/LibSource/ComplexFloatArray.h
+++ b/LibSource/ComplexFloatArray.h
@@ -2,7 +2,6 @@
 #define __ComplexFloatArray_h__
 
 #include "FloatArray.h"
-#include "AudioBuffer.h"
 #include "basicmaths.h"
 
 /**
@@ -133,7 +132,6 @@ struct ComplexFloat {
 
   ComplexFloat& operator+=(float other) {
     re += other;
-    im += other;
     return *this;
   }
 
@@ -157,7 +155,6 @@ struct ComplexFloat {
 
   ComplexFloat& operator-=(float other) {
     re -= other;
-    im -= other;
     return *this;
   }
 
@@ -501,8 +498,23 @@ public:
   */
   void setMagnitude(FloatArray magnitude, int offset, size_t count, ComplexFloatArray destination);
 
-  void copyFrom(AudioBuffer& buffer);
-  void copyTo(AudioBuffer& buffer);
+  using SimpleArray<ComplexFloat>::copyFrom;
+  using SimpleArray<ComplexFloat>::copyTo;
+  /**
+   * Merge two channels of audio containing real and imaginary axis data into this array
+   * 
+   * @param[in] real Real axis data
+   * @param[in] imag Imaginary axis data
+  */
+  void copyFrom(FloatArray real, FloatArray imag);
+
+  /**
+   * Split complex data into two channels of audio containing real and imaginary axis data
+   * 
+   * @param[in] real Real axis data
+   * @param[in] imag Imaginary axis data
+  */
+  void copyTo(FloatArray real, FloatArray imag);
 };
 
 #endif // __ComplexFloatArray_h__

--- a/LibSource/ComplexOscillator.h
+++ b/LibSource/ComplexOscillator.h
@@ -1,19 +1,22 @@
-#ifndef __QUADRATURE_OSCILLATOR_H__
-#define __QUADRATURE_OSCILLATOR_H__
+#ifndef __COMPLEX_OSCILLATOR_H__
+#define __COMPLEX_OSCILLATOR_H__
 
 #include "SignalGenerator.h"
 #include "Oscillator.h"
 #include "ComplexFloatArray.h"
 
 /**
- * A stereo oscillator is a MultiSignalGenerator with 2 channels that
+ * A complex oscillator is a MultiSignalGenerator with 2 channels that
  * operates at a given frequency and that can be frequency modulated. Output
- * signal is a complex number.
+ * signal is stereo signal.
+ * 
+ * A single sample is represented as a ComplexFloat value, while blocks
+ * of audio are stored as AudioBuffer with 2 channels.
  */
-class StereoOscillator : public MultiSignalGenerator {
+class ComplexOscillator : public MultiSignalGenerator {
 public:
-  StereoOscillator() = default;
-  virtual ~StereoOscillator() = default;
+  ComplexOscillator() = default;
+  virtual ~ComplexOscillator() = default;
   using MultiSignalGenerator::generate;
   /**
    * Set oscillator sample rate
@@ -60,5 +63,5 @@ public:
 };
 
 template<typename OscillatorClass>
-using StereoOscillatorTemplate = OscillatorTemplate<OscillatorClass, StereoOscillator, ComplexFloat>;
+using ComplexOscillatorTemplate = OscillatorTemplate<OscillatorClass, ComplexOscillator, ComplexFloat>;
 #endif

--- a/LibSource/ComplexOscillator.h
+++ b/LibSource/ComplexOscillator.h
@@ -7,11 +7,10 @@
 
 /**
  * A complex oscillator is a MultiSignalGenerator with 2 channels that
- * operates at a given frequency and that can be frequency modulated. Output
- * signal is stereo signal.
- * 
+ * operates at a given frequency and that can be frequency modulated.
+ *
  * A single sample is represented as a ComplexFloat value, while blocks
- * of audio are stored as AudioBuffer with 2 channels.
+ * of audio are stored in an AudioBuffer with 2 channels.
  */
 class ComplexOscillator : public MultiSignalGenerator {
 public:

--- a/LibSource/ComplexOscillator.h
+++ b/LibSource/ComplexOscillator.h
@@ -45,15 +45,15 @@ public:
   /**
    * Produce a sample with frequency modulation.
    */
-  virtual ComplexFloat generate() {
-    return generate(0.f);
-  }
   virtual ComplexFloat generate(float fm) = 0;
-  virtual void generate(ComplexFloatArray output) {
-    for(size_t i=0; i<output.getSize(); ++i) {
-      output[i]= generate();
-    }
+  /**
+   * Produce a block of samples with frequency modulation.
+   */
+  virtual void generate(ComplexFloatArray output, FloatArray fm){
+    for(size_t i=0; i<output.getSize(); ++i)
+      output[i] = generate(fm[i]);
   }
+
 };
 
 template<typename OscillatorClass>

--- a/LibSource/ComplexOscillator.h
+++ b/LibSource/ComplexOscillator.h
@@ -15,7 +15,7 @@ class ComplexOscillator : public ComplexSignalGenerator {
 public:
   ComplexOscillator() = default;
   virtual ~ComplexOscillator() = default;
-  using MultiSignalGenerator::generate;
+  using ComplexSignalGenerator::generate;
   /**
    * Set oscillator sample rate
    */

--- a/LibSource/ComplexOscillator.h
+++ b/LibSource/ComplexOscillator.h
@@ -3,7 +3,6 @@
 
 #include "SignalGenerator.h"
 #include "Oscillator.h"
-#include "ComplexFloatArray.h"
 
 /**
  * A complex oscillator is a MultiSignalGenerator with 2 channels that
@@ -12,7 +11,7 @@
  * A single sample is represented as a ComplexFloat value, while blocks
  * of audio are stored in an AudioBuffer with 2 channels.
  */
-class ComplexOscillator : public MultiSignalGenerator {
+class ComplexOscillator : public ComplexSignalGenerator {
 public:
   ComplexOscillator() = default;
   virtual ~ComplexOscillator() = default;
@@ -50,13 +49,9 @@ public:
     return generate(0.f);
   }
   virtual ComplexFloat generate(float fm) = 0;
-  virtual void generate(AudioBuffer& output) {
-    FloatArray left = output.getSamples(0);
-    FloatArray right = output.getSamples(1);
+  virtual void generate(ComplexFloatArray output) {
     for(size_t i=0; i<output.getSize(); ++i) {
-      ComplexFloat sample = generate();
-      left[i] = sample.re;
-      right[i] = sample.im;
+      output[i]= generate();
     }
   }
 };

--- a/LibSource/ComplexTransform.h
+++ b/LibSource/ComplexTransform.h
@@ -3,43 +3,88 @@
 
 #include "basicmaths.h"
 #include "SignalProcessor.h"
+#include "FloatMatrix.h"
 
-template <typename Operation, size_t matrix_dim>
-class ComplexTransformTemplate : public ComplexSignalProcessor {
+template <size_t matrix_order>
+class AbstractTransform {
 public:
-    using ComplexSignalProcessor::process;
-    ComplexTransformTemplate() {
-        memset((void*)&matrix[0][0], 0, sizeof(float) * matrix_dim * matrix_dim);
+    AbstractTransform() = default;
+    AbstractTransform(FloatMatrix matrix) {
+        this->matrix = matrix;
+        resetMatrix();
     }
-    ComplexFloat process(ComplexFloat input) {
-        // We can avoid template specialization in C++17 thanks to if constexpr() support
-        if constexpr (matrix_dim == 2) {
-            return ComplexFloat(
-                matrix[0][0] * input.re + matrix[0][1] * input.re,
-                matrix[1][0] * input.im + matrix[1][1] * input.im);
-        }
-        else {
-            return ComplexFloat(
-                matrix[0][0] * input.re + matrix[0][1] * input.re + matrix[0][2] * input.re,
-                matrix[1][0] * input.im + matrix[1][1] * input.im + matrix[1][2] * input.im);
+    FloatMatrix getMatrix() {
+        return matrix;
+    }
+    void resetMatrix() {
+        matrix.clear();
+        for (size_t i = 0; i < matrix_order; i++) {
+            matrix[i][i] = 1;
         }
     }
-    static Operation* create() {
-        return new Operation();
-    }
-    static void destroy(Operation* transform) {
-        delete transform;
-    }
-
 protected:
-    float matrix[matrix_dim][matrix_dim];
+    FloatMatrix matrix;
 };
 
-class Reflection2D : public ComplexTransformTemplate<Reflection2D, 2> {
+template <size_t matrix_order, typename Operation>
+class ComplexTransformTemplate : public AbstractTransform<matrix_order>,
+                                 public ComplexSignalProcessor {
 public:
-    Reflection2D() {
-        setAngle(0);
+    using AbstractTransform<matrix_order>::AbstractTransform;
+    using AbstractTransform<matrix_order>::matrix;
+    using ComplexSignalProcessor::process;
+
+
+
+    ComplexFloat process(ComplexFloat input) {
+        if constexpr (matrix_order == 2) {
+            return ComplexFloat(input.re * matrix[0][0] + input.im * matrix[0][1],
+                input.re * matrix[1][0] + input.im * matrix[1][1]);
+        }
+        else if constexpr (matrix_order == 3) {
+            return ComplexFloat(
+                input.re * matrix[0][0] + input.im * matrix[0][1] + matrix[0][2],
+                input.re * matrix[1][0] + input.im * matrix[1][1] + matrix[1][2]);
+        }
+        else if constexpr (matrix_order > 3) {
+            ComplexFloat result {
+                input.re * matrix[0][0] + input.im * matrix[0][1],
+                input.re * matrix[1][0] + input.im * matrix[1][1]};
+            for (size_t i = 2; i < matrix_order; i++) {
+                input.re += matrix[0][i];
+                input.im += matrix[0][i];
+            }
+        }
+        else {
+            return ComplexFloat {};
+        }
     }
+
+    static Operation* create() {
+        FloatMatrix matrix = FloatMatrix::create(matrix_order, matrix_order);
+        Operation* op = new Operation(matrix);
+        return op;
+    }
+    static void destroy(Operation* transform) {
+        FloatMatrix::destroy(transform->matrix);
+        delete transform;
+    }
+};
+
+class LinearReflection2D : public ComplexTransformTemplate<2, LinearReflection2D> {
+public:
+    using ComplexTransformTemplate<2, LinearReflection2D>::ComplexTransformTemplate;
+    void setAngle(float angle) {
+        matrix[0][0] = cos(angle * 2);
+        matrix[1][0] = sin(angle * 2);
+        matrix[0][1] = matrix[0][1];
+        matrix[1][1] = -matrix[0][0];
+    }
+};
+
+class AffineReflection2D : public ComplexTransformTemplate<3, AffineReflection2D> {
+public:
+    using ComplexTransformTemplate<3, AffineReflection2D>::ComplexTransformTemplate;
     void setAngle(float angle) {
         matrix[0][0] = cos(angle * 2);
         matrix[0][1] = sin(angle * 2);
@@ -48,8 +93,9 @@ public:
     }
 };
 
-class Rotation2D : public ComplexTransformTemplate<Rotation2D, 2> {
+class LinearRotation2D : public ComplexTransformTemplate<2, LinearRotation2D> {
 public:
+    using ComplexTransformTemplate<2, LinearRotation2D>::ComplexTransformTemplate;
     void setAngle(float angle) {
         matrix[0][0] = cos(angle);
         matrix[1][0] = sin(angle);
@@ -58,8 +104,20 @@ public:
     }
 };
 
-class Scale2D : public ComplexTransformTemplate<Scale2D, 2> {
+class AffineRotation2D : public ComplexTransformTemplate<3, AffineRotation2D> {
 public:
+    using ComplexTransformTemplate<3, AffineRotation2D>::ComplexTransformTemplate;
+    void setAngle(float angle) {
+        matrix[0][0] = cos(angle);
+        matrix[1][0] = sin(angle);
+        matrix[0][1] = -matrix[1][0];
+        matrix[1][1] = matrix[0][0];
+    }
+};
+
+class LinearScale2D : public ComplexTransformTemplate<2, LinearScale2D> {
+public:
+    using ComplexTransformTemplate<2, LinearScale2D>::ComplexTransformTemplate;
     void setDirection(ComplexFloat vector) {
         matrix[0][0] = vector.re;
         matrix[1][1] = vector.im;
@@ -70,72 +128,203 @@ public:
     }
 };
 
-class StretchX2D : public ComplexTransformTemplate<StretchX2D, 2> {
+class AffineScale2D : public ComplexTransformTemplate<3, AffineScale2D> {
 public:
-    StretchX2D() {
-        matrix[1][1] = 1;
+    using ComplexTransformTemplate<3, AffineScale2D>::ComplexTransformTemplate;
+    void setDirection(ComplexFloat vector) {
+        matrix[0][0] = vector.re;
+        matrix[1][1] = vector.im;
     }
-
-    void setFactor(float scale) {
-        matrix[0][0] = scale;
+    void setFactor(float factor) {
+        matrix[0][0] = factor;
+        matrix[1][1] = factor;
     }
 };
 
-class StretchY2D : public ComplexTransformTemplate<StretchY2D, 2> {
+class LinearStretch2D : public ComplexTransformTemplate<2, LinearStretch2D> {
 public:
-    StretchY2D() {
-        matrix[0][0] = 1;
-    }
-
-    void setFactor(float scale) {
-        matrix[1][1] = scale;
+    using ComplexTransformTemplate<2, LinearStretch2D>::ComplexTransformTemplate;
+    void setDirection(ComplexFloat vector) {
+        matrix[0][0] = vector.re;
+        matrix[1][1] = vector.im;
     }
 };
 
-class Squeeze2D : public ComplexTransformTemplate<Squeeze2D, 2> {
+class AffineStretch2D : public ComplexTransformTemplate<3, AffineStretch2D> {
 public:
+    using ComplexTransformTemplate<3, AffineStretch2D>::ComplexTransformTemplate;
+    void setDirection(ComplexFloat vector) {
+        matrix[0][0] = vector.re;
+        matrix[1][1] = vector.im;
+    }
+};
+
+class LinearSqueeze2D : public ComplexTransformTemplate<2, LinearSqueeze2D> {
+public:
+    using ComplexTransformTemplate<2, LinearSqueeze2D>::ComplexTransformTemplate;
     void setFactor(float scale) {
         matrix[0][0] = scale;
         matrix[1][1] = 1.f / scale;
     }
 };
 
-class ShearX2D : public ComplexTransformTemplate<ShearX2D, 2> {
+class LinearShearX2D : public ComplexTransformTemplate<2, LinearShearX2D> {
 public:
-    ShearX2D() {
-        matrix[0][0] = 1;
-        matrix[1][1] = 1;
-    }
-
+    using ComplexTransformTemplate<2, LinearShearX2D>::ComplexTransformTemplate;
     void setFactor(float scale) {
         matrix[0][1] = scale;
     }
 };
 
-class ShearY2D : public ComplexTransformTemplate<ShearY2D, 2> {
+class AffineShearX2D : public ComplexTransformTemplate<3, AffineShearX2D> {
 public:
-    ShearY2D() {
-        matrix[0][0] = 1;
-        matrix[1][1] = 1;
+    using ComplexTransformTemplate<3, AffineShearX2D>::ComplexTransformTemplate;
+    void setFactor(float scale) {
+        matrix[0][1] = scale;
     }
+};
 
+class LinearShearY2D : public ComplexTransformTemplate<2, LinearShearY2D> {
+public:
+    using ComplexTransformTemplate<2, LinearShearY2D>::ComplexTransformTemplate;
     void setFactor(float scale) {
         matrix[1][0] = scale;
     }
 };
 
-class Translate2D : public ComplexTransformTemplate<Translate2D, 3> {
+class AffineShearY2D : public ComplexTransformTemplate<3, AffineShearY2D> {
 public:
-    Translate2D() {
-        matrix[0][0] = 1;
-        matrix[1][1] = 1;
-        matrix[2][2] = 1;
+    using ComplexTransformTemplate<3, AffineShearY2D>::ComplexTransformTemplate;
+    void setFactor(float scale) {
+        matrix[1][0] = scale;
+    }
+};
+
+class AffineTranslate2D : public ComplexTransformTemplate<3, AffineTranslate2D> {
+public:
+    using ComplexTransformTemplate<3, AffineTranslate2D>::ComplexTransformTemplate;
+    void setDirection(ComplexFloat vector) {
+        matrix[2][0] = vector.re;
+        matrix[2][1] = vector.im;
+    }
+};
+
+template <size_t matrix_order>
+class CompositeTransform
+    : public ComplexTransformTemplate<matrix_order, CompositeTransform<matrix_order>> {
+public:
+    using BaseTransform = AbstractTransform<matrix_order>;
+    using BaseTransform::getMatrix;
+    using BaseTransform::matrix;
+
+    CompositeTransform(FloatMatrix matrix, size_t num_transforms, BaseTransform** transforms)
+        : ComplexTransformTemplate<matrix_order, CompositeTransform<matrix_order>>(matrix)
+        , transforms(transforms)
+        , num_transforms(num_transforms) {
     }
 
-    void setDirection(ComplexFloat vector) {
-        matrix[0][2] = vector.re;
-        matrix[1][2] = vector.im;
+    void process(ComplexFloatArray input, ComplexFloatArray output) {
+        computeMatrix();
+        ComplexTransformTemplate<matrix_order, CompositeTransform<matrix_order>>::process(
+            input, output);
     }
+    void computeMatrix() {
+        FloatMatrix m = this->matrix;
+        m.copyFrom(transforms[0]->getMatrix());
+        for (size_t i = 1; i < num_transforms; i++) {
+            m.multiply(transforms[i]->getMatrix());
+        }
+    }
+
+    void setTransform(size_t position, BaseTransform* transform) {
+        transforms[position] = transform;
+    }
+
+    static CompositeTransform* create(size_t transforms) {
+        FloatMatrix matrix = FloatMatrix::create(matrix_order, matrix_order);
+        BaseTransform** transform_pointers = new BaseTransform*[transforms];
+        return new CompositeTransform(matrix, transforms, transform_pointers);
+    }
+
+    static void destroy(CompositeTransform* transform) {
+        FloatMatrix::destroy(transform->matrix);
+        delete[] transform->transforms;
+        delete transform;
+    }
+
+protected:
+    BaseTransform** transforms;
+    size_t num_transforms;
+};
+
+template <size_t matrix_order>
+class InterpolatedCompositeTransform
+    : public ComplexTransformTemplate<matrix_order, CompositeTransform<matrix_order>> {
+public:
+    using BaseTransform = AbstractTransform<matrix_order>;
+    using BaseTransform::getMatrix;
+    using BaseTransform::matrix;
+    using ComplexTransformTemplate<matrix_order, CompositeTransform<matrix_order>>::process;
+
+    InterpolatedCompositeTransform(FloatMatrix matrix, FloatMatrix prev_matrix,
+        FloatMatrix delta, size_t num_transforms, BaseTransform** transforms)
+        : ComplexTransformTemplate<matrix_order, CompositeTransform<matrix_order>>(matrix)
+        , transforms(transforms)
+        , num_transforms(num_transforms)
+        , prev_matrix(prev_matrix)
+        , delta(delta) {
+    }
+
+    void process(ComplexFloatArray input, ComplexFloatArray output) {
+        computeMatrix();
+        float mult = 1.f / input.getSize();
+        for (size_t i = 0; i < matrix_order; i++) {
+            for (size_t j = 0; j < matrix_order; j++) {
+                delta[i][j] = (matrix[i][j] - prev_matrix[i][j]) * mult;
+            }
+        }
+
+        matrix.copyFrom(prev_matrix);
+        for (size_t i = 0; i < input.getSize(); i++) {
+            matrix.add(delta);
+            output[i] = process(input[i]);
+        }
+        prev_matrix.copyFrom(matrix);
+    }
+    void computeMatrix() {
+        FloatMatrix m = this->matrix;
+
+        m.copyFrom(transforms[num_transforms - 1]->getMatrix());
+        for (int i = num_transforms - 2; i >= 0; i--) {
+            m.multiply(transforms[i]->getMatrix());
+        }
+    }
+
+    void setTransform(size_t position, BaseTransform* transform) {
+        transforms[position] = transform;
+    }
+
+    static InterpolatedCompositeTransform* create(size_t transforms) {
+        FloatMatrix matrix = FloatMatrix::create(matrix_order, matrix_order);
+        BaseTransform** transform_pointers = new BaseTransform*[transforms];
+        FloatMatrix prev_matrix = FloatMatrix::create(matrix_order, matrix_order);
+        FloatMatrix delta = FloatMatrix::create(matrix_order, matrix_order);
+        return new InterpolatedCompositeTransform(
+            matrix, prev_matrix, delta, transforms, transform_pointers);
+    }
+
+    static void destroy(InterpolatedCompositeTransform* transform) {
+        FloatMatrix::destroy(transform->matrix);
+        FloatMatrix::destroy(transform->prev_matrix);
+        FloatMatrix::destroy(transform->delta);
+        delete[] transform->transforms;
+        delete transform;
+    }
+
+protected:
+    BaseTransform** transforms;
+    size_t num_transforms;
+    FloatMatrix prev_matrix, delta;
 };
 
 #endif

--- a/LibSource/ComplexTransform.h
+++ b/LibSource/ComplexTransform.h
@@ -1,0 +1,141 @@
+#ifndef __COMPLEX_TRANSFORM_H__
+#define __COMPLEX_TRANSFORM_H__
+
+#include "basicmaths.h"
+#include "SignalProcessor.h"
+
+template <typename Operation, size_t matrix_dim>
+class ComplexTransformTemplate : public ComplexSignalProcessor {
+public:
+    using ComplexSignalProcessor::process;
+    ComplexTransformTemplate() {
+        memset((void*)&matrix[0][0], 0, sizeof(float) * matrix_dim * matrix_dim);
+    }
+    ComplexFloat process(ComplexFloat input) {
+        // We can avoid template specialization in C++17 thanks to if constexpr() support
+        if constexpr (matrix_dim == 2) {
+            return ComplexFloat(
+                matrix[0][0] * input.re + matrix[0][1] * input.re,
+                matrix[1][0] * input.im + matrix[1][1] * input.im);
+        }
+        else {
+            return ComplexFloat(
+                matrix[0][0] * input.re + matrix[0][1] * input.re + matrix[0][2] * input.re,
+                matrix[1][0] * input.im + matrix[1][1] * input.im + matrix[1][2] * input.im);
+        }
+    }
+    static Operation* create() {
+        return new Operation();
+    }
+    static void destroy(Operation* transform) {
+        delete transform;
+    }
+
+protected:
+    float matrix[matrix_dim][matrix_dim];
+};
+
+class Reflection2D : public ComplexTransformTemplate<Reflection2D, 2> {
+public:
+    Reflection2D() {
+        setAngle(0);
+    }
+    void setAngle(float angle) {
+        matrix[0][0] = cos(angle * 2);
+        matrix[0][1] = sin(angle * 2);
+        matrix[1][0] = matrix[0][1];
+        matrix[1][1] = -matrix[0][0];
+    }
+};
+
+class Rotation2D : public ComplexTransformTemplate<Rotation2D, 2> {
+public:
+    void setAngle(float angle) {
+        matrix[0][0] = cos(angle);
+        matrix[1][0] = sin(angle);
+        matrix[0][1] = -matrix[1][0];
+        matrix[1][1] = matrix[0][0];
+    }
+};
+
+class Scale2D : public ComplexTransformTemplate<Scale2D, 2> {
+public:
+    void setDirection(ComplexFloat vector) {
+        matrix[0][0] = vector.re;
+        matrix[1][1] = vector.im;
+    }
+    void setFactor(float factor) {
+        matrix[0][0] = factor;
+        matrix[1][1] = factor;
+    }
+};
+
+class StretchX2D : public ComplexTransformTemplate<StretchX2D, 2> {
+public:
+    StretchX2D() {
+        matrix[1][1] = 1;
+    }
+
+    void setFactor(float scale) {
+        matrix[0][0] = scale;
+    }
+};
+
+class StretchY2D : public ComplexTransformTemplate<StretchY2D, 2> {
+public:
+    StretchY2D() {
+        matrix[0][0] = 1;
+    }
+
+    void setFactor(float scale) {
+        matrix[1][1] = scale;
+    }
+};
+
+class Squeeze2D : public ComplexTransformTemplate<Squeeze2D, 2> {
+public:
+    void setFactor(float scale) {
+        matrix[0][0] = scale;
+        matrix[1][1] = 1.f / scale;
+    }
+};
+
+class ShearX2D : public ComplexTransformTemplate<ShearX2D, 2> {
+public:
+    ShearX2D() {
+        matrix[0][0] = 1;
+        matrix[1][1] = 1;
+    }
+
+    void setFactor(float scale) {
+        matrix[0][1] = scale;
+    }
+};
+
+class ShearY2D : public ComplexTransformTemplate<ShearY2D, 2> {
+public:
+    ShearY2D() {
+        matrix[0][0] = 1;
+        matrix[1][1] = 1;
+    }
+
+    void setFactor(float scale) {
+        matrix[1][0] = scale;
+    }
+};
+
+class Translate2D : public ComplexTransformTemplate<Translate2D, 3> {
+public:
+    Translate2D() {
+        matrix[0][0] = 1;
+        matrix[1][1] = 1;
+        matrix[2][2] = 1;
+    }
+
+    void setDirection(ComplexFloat vector) {
+        matrix[0][2] = vector.re;
+        matrix[1][2] = vector.im;
+    }
+};
+
+#endif

--- a/LibSource/FloatMatrix.cpp
+++ b/LibSource/FloatMatrix.cpp
@@ -1,6 +1,7 @@
 #include "FloatMatrix.h"
 #include "basicmaths.h"
 #include "message.h"
+#include <cstring>
 
 #ifdef ARM_CORTEX
 FloatMatrix::FloatMatrix(){
@@ -122,6 +123,16 @@ void FloatMatrix::sigmoid(FloatMatrix destination){
   size_t size = getSize();
   for(size_t i = 0; i < size; i++)
     dest[i] = 1.0f / (1 + expf(-src[i]));
+}
+
+void FloatMatrix::copyTo(FloatMatrix destination) {
+  ASSERT(destination.getSize() >= getSize(), "Destination size too small");
+  memcpy((void*)destination.getData(), (void*)getData(), getSize() * sizeof(float));
+}
+
+void FloatMatrix::copyFrom(FloatMatrix source) {
+  ASSERT(getSize() >= source.getSize(), "Destination size too small");
+  memcpy((void*)getData(), (void*)source.getData(), source.getSize() * sizeof(float));
 }
 
 FloatMatrix FloatMatrix::create(size_t m, size_t n){

--- a/LibSource/FloatMatrix.cpp
+++ b/LibSource/FloatMatrix.cpp
@@ -132,9 +132,9 @@ FloatMatrix FloatMatrix::create(size_t m, size_t n){
   
  void FloatMatrix::destroy(FloatMatrix array){
 #ifdef ARM_CORTEX
-  delete array.instance.pData;
+  delete[] array.instance.pData;
 #else
-  delete array.data;
+  delete[] array.data;
 #endif
 };
 

--- a/LibSource/FloatMatrix.h
+++ b/LibSource/FloatMatrix.h
@@ -168,6 +168,20 @@ public:
   }
 
   /**
+   * Copies the content of this matrix to another matrix.
+   * The other matrix needs to be at least as big as this matrix.
+   * @param[out] destination the destination matrix
+   */
+  void copyTo(FloatMatrix destination);
+
+  /**
+   * Copies the content of another matrix into this matrix.
+   * This matrix needs to be at least as big as the other matrix.
+   * @param[in] source the source matrix
+   */
+  void copyFrom(FloatMatrix source);
+
+  /**
    * Creates a new FloatMatrix.
    * Allocates rows*columns*sizeof(float) bytes of memory and returns a FloatMatrix that points to it.
    * @param rows the number of rows of the new FloatMatrix.

--- a/LibSource/Oscillator.h
+++ b/LibSource/Oscillator.h
@@ -65,8 +65,8 @@ public:
   }
 };
 
-template<class T>
-class OscillatorTemplate : public Oscillator {
+template<class T, class BaseOscillator=Oscillator, typename Sample=float>
+class OscillatorTemplate : public BaseOscillator {
 protected:
   float mul;
   float phase = 0;
@@ -96,22 +96,22 @@ public:
   void reset(){
     phase = T::begin_phase;
   }
-  float generate(){
-    float sample = static_cast<T*>(this)->getSample();
+  Sample generate() override {
+    Sample sample = static_cast<T*>(this)->getSample();
     phase += incr;
     if(phase >= T::end_phase)
       phase -= (T::end_phase - T::begin_phase);
     return sample;
   }
-  float generate(float fm){
-    float sample = static_cast<T*>(this)->getSample();
+  Sample generate(float fm) override {
+    Sample sample = static_cast<T*>(this)->getSample();
     // phase += incr * (1 + fm);
     phase += incr  + (T::end_phase - T::begin_phase)*fm;
     if(phase >= T::end_phase)
       phase -= (T::end_phase - T::begin_phase);
     return sample;
   }  
-  using Oscillator::generate;
+  using BaseOscillator::generate;
   static T* create(float sr){
     T* obj = new T();
     obj->setSampleRate(sr);

--- a/LibSource/Oscillator.h
+++ b/LibSource/Oscillator.h
@@ -68,7 +68,7 @@ public:
 template<class T, class BaseOscillator=Oscillator, typename Sample=float>
 class OscillatorTemplate : public BaseOscillator {
 protected:
-  float mul;
+  float mul = 1;  // Prevent having NaN as default getFrequency result
   float phase = 0;
   float incr = 0;
 public:

--- a/LibSource/QuadratureSineOscillator.h
+++ b/LibSource/QuadratureSineOscillator.h
@@ -1,0 +1,39 @@
+#ifndef QUADRATURE_SINE_OSCILLATOR_H
+#define QUADRATURE_SINE_OSCILLATOR_H
+
+#include "StereoOscillator.h"
+
+class QuadratureSineOscillator : public StereoOscillatorTemplate<QuadratureSineOscillator> {
+public:
+    static constexpr float begin_phase = 0;
+    static constexpr float end_phase = 2 * M_PI;
+    ComplexFloat getSample() {
+        return ComplexFloat { cosf(phase), sinf(phase) };
+    }
+    void generate(AudioBuffer& output) override {
+        size_t len = output.getSize();
+        FloatArray left = output.getSamples(0);
+        FloatArray right = output.getSamples(1);
+        for (size_t i = 0; i < len; ++i) {
+            left[i] = cosf(phase);
+            right[i] = sinf(phase);
+            phase += incr; // allow phase to overrun
+        }
+        phase = fmodf(phase, end_phase);
+    }
+    void generate(AudioBuffer& output, FloatArray fm) {
+        size_t len = output.getSize();
+        FloatArray left = output.getSamples(0);
+        FloatArray right = output.getSamples(1);
+        for (size_t i = 0; i < len; ++i) {
+            left[i] = cosf(phase);
+            right[i] = sinf(phase);
+            phase += incr * (1 + fm[i]);
+            // allow phase to overrun
+        }
+        phase = fmodf(phase, end_phase);
+    }
+    using StereoOscillatorTemplate<QuadratureSineOscillator>::generate;
+};
+
+#endif /* QUADRATURE_SINE_OSCILLATOR_H */

--- a/LibSource/QuadratureSineOscillator.h
+++ b/LibSource/QuadratureSineOscillator.h
@@ -1,9 +1,9 @@
 #ifndef QUADRATURE_SINE_OSCILLATOR_H
 #define QUADRATURE_SINE_OSCILLATOR_H
 
-#include "StereoOscillator.h"
+#include "ComplexOscillator.h"
 
-class QuadratureSineOscillator : public StereoOscillatorTemplate<QuadratureSineOscillator> {
+class QuadratureSineOscillator : public ComplexOscillatorTemplate<QuadratureSineOscillator> {
 public:
     static constexpr float begin_phase = 0;
     static constexpr float end_phase = 2 * M_PI;
@@ -33,7 +33,7 @@ public:
         }
         phase = fmodf(phase, end_phase);
     }
-    using StereoOscillatorTemplate<QuadratureSineOscillator>::generate;
+    using ComplexOscillatorTemplate<QuadratureSineOscillator>::generate;
 };
 
 #endif /* QUADRATURE_SINE_OSCILLATOR_H */

--- a/LibSource/QuadratureSineOscillator.h
+++ b/LibSource/QuadratureSineOscillator.h
@@ -3,6 +3,11 @@
 
 #include "ComplexOscillator.h"
 
+/**
+ * Oscillator outputs complex numbers on unit cycle. This means that axis are
+ * 90 degrees out of phase at any point of time and oscillator's magnitude is
+ * always equal to 1.0
+ **/
 class QuadratureSineOscillator : public ComplexOscillatorTemplate<QuadratureSineOscillator> {
 public:
     static constexpr float begin_phase = 0;
@@ -19,7 +24,7 @@ public:
         }
         phase = fmodf(phase, end_phase);
     }
-    void generate(ComplexFloatArray output, FloatArray fm) {
+    void generate(ComplexFloatArray output, FloatArray fm) override {
         size_t len = output.getSize();
         for (size_t i = 0; i < len; ++i) {
             output[i].re = cosf(phase);
@@ -32,12 +37,20 @@ public:
     using ComplexOscillatorTemplate<QuadratureSineOscillator>::generate;
 };
 
+/**
+ * An oscillator similar to QuadratureSineOscillator class that also includes
+ * feedback control. Feedback value is a scalar value, meaning that both real and
+ * imaginary axis get the same amount of feeback
+ **/
 class FeedbackQuadratureSineOscillator : public ComplexOscillatorTemplate<FeedbackQuadratureSineOscillator> {
 public:
     static constexpr float begin_phase = 0;
     static constexpr float end_phase = 2 * M_PI;
     void setFeedback(float feedback) {
         this->feedback = feedback;
+    }
+    float getFeedback() const {
+        return feedback;
     }
     ComplexFloat getSample() {
         last_sample = ComplexFloat(
@@ -54,7 +67,7 @@ public:
         }
         phase = fmodf(phase, end_phase);
     }
-    void generate(ComplexFloatArray output, FloatArray fm) {
+    void generate(ComplexFloatArray output, FloatArray fm) override {
         size_t len = output.getSize();
         for (size_t i = 0; i < len; ++i) {
             output[i].re = cosf(phase + last_sample.re * feedback);
@@ -68,6 +81,54 @@ public:
     using ComplexOscillatorTemplate<FeedbackQuadratureSineOscillator>::generate;
 protected:
     float feedback = 0;
+    ComplexFloat last_sample = 0;
+};
+
+
+/**
+ * An oscillator similar to QuadratureSineOscillator class that also includes
+ * feedback control. Feedback value is a complex number, this allows controlling
+ * feedback direction.
+ **/
+class ComplexFeedbackQuadratureSineOscillator : public ComplexOscillatorTemplate<ComplexFeedbackQuadratureSineOscillator> {
+public:
+    static constexpr float begin_phase = 0;
+    static constexpr float end_phase = 2 * M_PI;
+    void setFeedback(ComplexFloat feedback) {
+        this->feedback = feedback;
+    }
+    ComplexFloat getFeedback() const {
+        return feedback;
+    }
+    ComplexFloat getSample() {
+        last_sample = ComplexFloat(
+            cosf(phase + last_sample.re * feedback.re), sinf(phase + last_sample.im * feedback.im));
+        return last_sample;
+    }
+    void generate(ComplexFloatArray output) override {
+        size_t len = output.getSize();
+        for (size_t i = 0; i < len; ++i) {
+            output[i].re = cosf(phase + last_sample.re * feedback.re);
+            output[i].im = sinf(phase + last_sample.im * feedback.im);
+            last_sample = output[i];
+            phase += incr; // allow phase to overrun
+        }
+        phase = fmodf(phase, end_phase);
+    }
+    void generate(ComplexFloatArray output, FloatArray fm) override {
+        size_t len = output.getSize();
+        for (size_t i = 0; i < len; ++i) {
+            output[i].re = cosf(phase + last_sample.re * feedback.re);
+            output[i].im = sinf(phase + last_sample.im * feedback.im);
+            last_sample = output[i];
+            phase += incr * (1 + fm[i]);
+            // allow phase to overrun
+        }
+        phase = fmodf(phase, end_phase);
+    }
+    using ComplexOscillatorTemplate<ComplexFeedbackQuadratureSineOscillator>::generate;
+protected:
+    ComplexFloat feedback = 0;
     ComplexFloat last_sample = 0;
 };
 

--- a/LibSource/QuadratureSineOscillator.h
+++ b/LibSource/QuadratureSineOscillator.h
@@ -10,30 +10,65 @@ public:
     ComplexFloat getSample() {
         return ComplexFloat { cosf(phase), sinf(phase) };
     }
-    void generate(AudioBuffer& output) override {
+    void generate(ComplexFloatArray output) override {
         size_t len = output.getSize();
-        FloatArray left = output.getSamples(0);
-        FloatArray right = output.getSamples(1);
         for (size_t i = 0; i < len; ++i) {
-            left[i] = cosf(phase);
-            right[i] = sinf(phase);
+            output[i].re = cosf(phase);
+            output[i].im = sinf(phase);
             phase += incr; // allow phase to overrun
         }
         phase = fmodf(phase, end_phase);
     }
-    void generate(AudioBuffer& output, FloatArray fm) {
+    void generate(ComplexFloatArray output, FloatArray fm) {
         size_t len = output.getSize();
-        FloatArray left = output.getSamples(0);
-        FloatArray right = output.getSamples(1);
         for (size_t i = 0; i < len; ++i) {
-            left[i] = cosf(phase);
-            right[i] = sinf(phase);
+            output[i].re = cosf(phase);
+            output[i].im = sinf(phase);
             phase += incr * (1 + fm[i]);
             // allow phase to overrun
         }
         phase = fmodf(phase, end_phase);
     }
     using ComplexOscillatorTemplate<QuadratureSineOscillator>::generate;
+};
+
+class FeedbackQuadratureSineOscillator : public ComplexOscillatorTemplate<FeedbackQuadratureSineOscillator> {
+public:
+    static constexpr float begin_phase = 0;
+    static constexpr float end_phase = 2 * M_PI;
+    void setFeedback(float feedback) {
+        this->feedback = feedback;
+    }
+    ComplexFloat getSample() {
+        last_sample = ComplexFloat(
+            cosf(phase + last_sample.re * feedback), sinf(phase + last_sample.im * feedback));
+        return last_sample;
+    }
+    void generate(ComplexFloatArray output) override {
+        size_t len = output.getSize();
+        for (size_t i = 0; i < len; ++i) {
+            output[i].re = cosf(phase + last_sample.re * feedback);
+            output[i].im = sinf(phase + last_sample.im * feedback);
+            last_sample = output[i];
+            phase += incr; // allow phase to overrun
+        }
+        phase = fmodf(phase, end_phase);
+    }
+    void generate(ComplexFloatArray output, FloatArray fm) {
+        size_t len = output.getSize();
+        for (size_t i = 0; i < len; ++i) {
+            output[i].re = cosf(phase + last_sample.re * feedback);
+            output[i].im = sinf(phase + last_sample.im * feedback);
+            last_sample = output[i];
+            phase += incr * (1 + fm[i]);
+            // allow phase to overrun
+        }
+        phase = fmodf(phase, end_phase);
+    }
+    using ComplexOscillatorTemplate<FeedbackQuadratureSineOscillator>::generate;
+protected:
+    float feedback = 0;
+    ComplexFloat last_sample = 0;
 };
 
 #endif /* QUADRATURE_SINE_OSCILLATOR_H */

--- a/LibSource/SignalGenerator.h
+++ b/LibSource/SignalGenerator.h
@@ -40,7 +40,7 @@ public:
  * in [-1..1] range unless
  * otherwise stated.
  */
-class ComplexSignalGenerator : public MultiSignalGenerator {
+class ComplexSignalGenerator {
 public:
   virtual ~ComplexSignalGenerator(){}
   /**
@@ -50,14 +50,10 @@ public:
   /**
    * Produce a block of samples
    */
-  virtual void generate(AudioBuffer& output) override{
+  virtual void generate(ComplexFloatArray output) {
     size_t size = output.getSize();
-    FloatArray left = output.getSamples(0);
-    FloatArray right = output.getSamples(1);
     for(size_t i=0; i<size; ++i) {
-      ComplexFloat sample = generate();
-      left[i] = sample.re;
-      right[i] = sample.im;
+      output[i] = generate();
     }
   }
 };

--- a/LibSource/SignalGenerator.h
+++ b/LibSource/SignalGenerator.h
@@ -2,6 +2,7 @@
 #define __SignalGenerator_h__
 
 #include "FloatArray.h"
+#include "ComplexFloatArray.h"
 #include "AudioBuffer.h"
 
 /**
@@ -25,10 +26,39 @@ public:
   }
 };
 
+
 class MultiSignalGenerator {
 public:
   virtual ~MultiSignalGenerator(){}
   virtual void generate(AudioBuffer& output) = 0;
 };
 
+
+/**
+ * Base class for stereo signal generators such as Oscillators.
+ * A ComplexSignalGenerator produces complex numbers with parts
+ * in [-1..1] range unless
+ * otherwise stated.
+ */
+class ComplexSignalGenerator : public MultiSignalGenerator {
+public:
+  virtual ~ComplexSignalGenerator(){}
+  /**
+   * Produce the next consecutive sample.
+   */
+  virtual ComplexFloat generate() = 0;
+  /**
+   * Produce a block of samples
+   */
+  virtual void generate(AudioBuffer& output) override{
+    size_t size = output.getSize();
+    FloatArray left = output.getSamples(0);
+    FloatArray right = output.getSamples(1);
+    for(size_t i=0; i<size; ++i) {
+      ComplexFloat sample = generate();
+      left[i] = sample.re;
+      right[i] = sample.im;
+    }
+  }
+};
 #endif // __SignalGenerator_h__

--- a/LibSource/SignalGenerator.h
+++ b/LibSource/SignalGenerator.h
@@ -36,9 +36,8 @@ public:
 
 /**
  * Base class for stereo signal generators such as Oscillators.
- * A ComplexSignalGenerator produces complex numbers with parts
- * in [-1..1] range unless
- * otherwise stated.
+ * A ComplexSignalGenerator produces complex numbers with each channel
+ * containing samples in [-1..1] range unless otherwise stated.
  */
 class ComplexSignalGenerator {
 public:

--- a/LibSource/SignalProcessor.h
+++ b/LibSource/SignalProcessor.h
@@ -2,6 +2,7 @@
 #define __SignalProcessor_h__
 
 #include "FloatArray.h"
+#include "ComplexFloatArray.h"
 
 /**
  * Base class for signal processors such as Filters
@@ -23,4 +24,13 @@ public:
   virtual void process(AudioBuffer& input, AudioBuffer& output) = 0;
 };
 
+class ComplexSignalProcessor {
+public:
+  virtual ~ComplexSignalProcessor(){}
+  virtual ComplexFloat process(ComplexFloat input) = 0;
+  virtual void process(ComplexFloatArray input, ComplexFloatArray output) {
+    for (size_t i = 0; i < output.getSize(); i++)
+      output[i] = process(ComplexFloat(input[i]));
+  }
+};
 #endif // __SignalProcessor_h__

--- a/LibSource/StereoOscillator.h
+++ b/LibSource/StereoOscillator.h
@@ -1,0 +1,64 @@
+#ifndef __QUADRATURE_OSCILLATOR_H__
+#define __QUADRATURE_OSCILLATOR_H__
+
+#include "SignalGenerator.h"
+#include "Oscillator.h"
+#include "ComplexFloatArray.h"
+
+/**
+ * A stereo oscillator is a MultiSignalGenerator with 2 channels that
+ * operates at a given frequency and that can be frequency modulated. Output
+ * signal is a complex number.
+ */
+class StereoOscillator : public MultiSignalGenerator {
+public:
+  StereoOscillator() = default;
+  virtual ~StereoOscillator() = default;
+  using MultiSignalGenerator::generate;
+  /**
+   * Set oscillator sample rate
+   */
+  virtual void setSampleRate(float value){}
+  /**
+   * Set oscillator frequency in Hertz
+   */
+  virtual void setFrequency(float value) = 0;
+  /**
+   * Get oscillator frequency in Hertz
+   */
+  virtual float getFrequency() = 0;
+  /**
+   * Set current oscillator phase in radians
+   * @param phase a value between 0 and 2*pi
+   */
+  virtual void setPhase(float phase) = 0;
+  /**
+   * Get current oscillator phase in radians
+   * @return a value between 0 and 2*pi
+   */
+  virtual float getPhase() = 0;
+  /**
+   * Reset oscillator (typically resets phase)
+   */
+  virtual void reset() = 0;
+  /**
+   * Produce a sample with frequency modulation.
+   */
+  virtual ComplexFloat generate() {
+    return generate(0.f);
+  }
+  virtual ComplexFloat generate(float fm) = 0;
+  virtual void generate(AudioBuffer& output) {
+    FloatArray left = output.getSamples(0);
+    FloatArray right = output.getSamples(1);
+    for(size_t i=0; i<output.getSize(); ++i) {
+      ComplexFloat sample = generate();
+      left[i] = sample.re;
+      right[i] = sample.im;
+    }
+  }
+};
+
+template<typename OscillatorClass>
+using StereoOscillatorTemplate = OscillatorTemplate<OscillatorClass, StereoOscillator, ComplexFloat>;
+#endif

--- a/TestPatches/QuadratureSineOscillatorTestPatch.hpp
+++ b/TestPatches/QuadratureSineOscillatorTestPatch.hpp
@@ -1,0 +1,72 @@
+#include "TestPatch.hpp"
+#include "QuadratureSineOscillator.h"
+
+class QuadratureSineOscillatorTestPatch : public TestPatch {
+public:
+  QuadratureSineOscillatorTestPatch(){
+    {
+      TEST("ctor");
+      QuadratureSineOscillator osc;
+      osc.setSampleRate(16000);
+      osc.setFrequency(440);
+      CHECK_EQUAL(osc.getSampleRate(), 16000);
+      CHECK_EQUAL((int)osc.getFrequency(), 440);
+      osc = QuadratureSineOscillator();
+      osc.setSampleRate(32000);
+      CHECK_EQUAL(osc.getFrequency(), 0.0f);
+      CHECK_EQUAL(osc.getSampleRate(), 32000);
+    }
+    {
+      TEST("create");
+      QuadratureSineOscillator* osc = QuadratureSineOscillator::create(32000);
+      osc->setFrequency(120);
+      CHECK_EQUAL(osc->getSampleRate(), 32000);
+      CHECK_EQUAL(osc->getFrequency(), 120);
+      QuadratureSineOscillator::destroy(osc);
+    }
+    {
+      TEST("setSampleRate");
+      QuadratureSineOscillator* osc = QuadratureSineOscillator::create(44100);
+      osc->setFrequency(321);
+      CHECK_EQUAL(osc->getSampleRate(), 44100);
+      CHECK_EQUAL(osc->getFrequency(), 321);
+      osc->setSampleRate(48000);
+      CHECK_EQUAL((int)osc->getSampleRate(), 48000);
+      CHECK_EQUAL(osc->getFrequency(), 321); // check that frequency is the same
+      QuadratureSineOscillator::destroy(osc);      
+    }
+    {
+      TEST("compareBlockAndSampleBased");
+      QuadratureSineOscillator* osc1 = QuadratureSineOscillator::create(48000);
+      QuadratureSineOscillator* osc2 = QuadratureSineOscillator::create(48000);
+      osc1->setFrequency(480);      
+      osc2->setFrequency(480);      
+      AudioBuffer* s1 = AudioBuffer::create(2, 1000);
+      AudioBuffer* s2 = AudioBuffer::create(2, 1000);
+      osc1->generate(*s1);
+      for(size_t i=0; i<1000; ++i) {
+        ComplexFloat sample = osc2->generate();
+        s2->getSamples(0)[i] = sample.re;
+        s2->getSamples(1)[i] = sample.im;
+      }
+      for(size_t i=0; i<1000; ++i) {
+        CHECK_CLOSE(s1->getSamples(0)[i], s2->getSamples(0)[i], 0.00002);
+        CHECK_CLOSE(s1->getSamples(1)[i], s2->getSamples(1)[i], 0.00002);
+      }
+      osc1->generate(*s1);
+      for(size_t i=0; i<1000; ++i) {
+        ComplexFloat sample = osc2->generate();
+        s2->getSamples(0)[i] = sample.re;
+        s2->getSamples(1)[i] = sample.im;
+      }
+      for(size_t i=0; i<1000; ++i) {
+        CHECK_CLOSE(s1->getSamples(0)[i], s2->getSamples(0)[i], 0.00002);
+        CHECK_CLOSE(s1->getSamples(1)[i], s2->getSamples(1)[i], 0.00002);
+      }
+      AudioBuffer::destroy(s1);      
+      AudioBuffer::destroy(s2);      
+      QuadratureSineOscillator::destroy(osc1);      
+      QuadratureSineOscillator::destroy(osc2);      
+    }
+}
+};

--- a/TestPatches/QuadratureSineOscillatorTestPatch.hpp
+++ b/TestPatches/QuadratureSineOscillatorTestPatch.hpp
@@ -43,7 +43,9 @@ public:
       osc2->setFrequency(480);      
       AudioBuffer* s1 = AudioBuffer::create(2, 1000);
       AudioBuffer* s2 = AudioBuffer::create(2, 1000);
-      osc1->generate(*s1);
+      ComplexFloatArray cmp = ComplexFloatArray::create(1000);
+      osc1->generate(cmp);
+      cmp.copyTo(s1->getSamples(0), s2->getSamples(1));
       for(size_t i=0; i<1000; ++i) {
         ComplexFloat sample = osc2->generate();
         s2->getSamples(0)[i] = sample.re;
@@ -53,15 +55,15 @@ public:
         CHECK_CLOSE(s1->getSamples(0)[i], s2->getSamples(0)[i], 0.00002);
         CHECK_CLOSE(s1->getSamples(1)[i], s2->getSamples(1)[i], 0.00002);
       }
-      osc1->generate(*s1);
+      osc1->generate(cmp);
       for(size_t i=0; i<1000; ++i) {
         ComplexFloat sample = osc2->generate();
         s2->getSamples(0)[i] = sample.re;
         s2->getSamples(1)[i] = sample.im;
       }
       for(size_t i=0; i<1000; ++i) {
-        CHECK_CLOSE(s1->getSamples(0)[i], s2->getSamples(0)[i], 0.00002);
-        CHECK_CLOSE(s1->getSamples(1)[i], s2->getSamples(1)[i], 0.00002);
+        CHECK_CLOSE(cmp[i].re, s2->getSamples(0)[i], 0.00002);
+        CHECK_CLOSE(cmp[i].im, s2->getSamples(1)[i], 0.00002);
       }
       AudioBuffer::destroy(s1);      
       AudioBuffer::destroy(s2);      

--- a/TestPatches/QuadratureSineOscillatorTestPatch.hpp
+++ b/TestPatches/QuadratureSineOscillatorTestPatch.hpp
@@ -45,13 +45,15 @@ public:
       AudioBuffer* s2 = AudioBuffer::create(2, 1000);
       ComplexFloatArray cmp = ComplexFloatArray::create(1000);
       osc1->generate(cmp);
-      cmp.copyTo(s1->getSamples(0), s2->getSamples(1));
+      cmp.copyTo(s1->getSamples(0), s1->getSamples(1));
       for(size_t i=0; i<1000; ++i) {
         ComplexFloat sample = osc2->generate();
         s2->getSamples(0)[i] = sample.re;
         s2->getSamples(1)[i] = sample.im;
       }
       for(size_t i=0; i<1000; ++i) {
+        CHECK_CLOSE(cmp[i].re, s2->getSamples(0)[i], 0.00002);
+        CHECK_CLOSE(cmp[i].im, s2->getSamples(1)[i], 0.00002);
         CHECK_CLOSE(s1->getSamples(0)[i], s2->getSamples(0)[i], 0.00002);
         CHECK_CLOSE(s1->getSamples(1)[i], s2->getSamples(1)[i], 0.00002);
       }
@@ -65,10 +67,10 @@ public:
         CHECK_CLOSE(cmp[i].re, s2->getSamples(0)[i], 0.00002);
         CHECK_CLOSE(cmp[i].im, s2->getSamples(1)[i], 0.00002);
       }
-      AudioBuffer::destroy(s1);      
-      AudioBuffer::destroy(s2);      
-      QuadratureSineOscillator::destroy(osc1);      
-      QuadratureSineOscillator::destroy(osc2);      
+      AudioBuffer::destroy(s1);
+      AudioBuffer::destroy(s2);
+      QuadratureSineOscillator::destroy(osc1);
+      QuadratureSineOscillator::destroy(osc2);
     }
 }
 };

--- a/TestPatches/SineOscillatorTestPatch.hpp
+++ b/TestPatches/SineOscillatorTestPatch.hpp
@@ -45,14 +45,14 @@ public:
       FloatArray s2 = FloatArray::create(1000);
       osc1->generate(s1);
       for(size_t i=0; i<1000; ++i)
-	s2[i] = osc2->generate();
+        s2[i] = osc2->generate();
       for(size_t i=0; i<1000; ++i)
-	CHECK_CLOSE(s1[i], s2[i], 0.00002);
+        CHECK_CLOSE(s1[i], s2[i], 0.00002);
       osc1->generate(s1);
       for(size_t i=0; i<1000; ++i)
-	s2[i] = osc2->generate();
+        s2[i] = osc2->generate();
       for(size_t i=0; i<1000; ++i)
-	CHECK_CLOSE(s1[i], s2[i], 0.00002);
+        CHECK_CLOSE(s1[i], s2[i], 0.00002);
       FloatArray::destroy(s1);      
       FloatArray::destroy(s2);      
       SineOscillator::destroy(osc1);      

--- a/TestPatches/fileio.h
+++ b/TestPatches/fileio.h
@@ -41,7 +41,7 @@ extern "C"{
         errx(1, "Data buffer not specified");
     if ((fd = creat(file_name, 0666)) < 1)
         errx(1, "Error creating file");
-    if (write(fd, data, size) < size)
+    if (write(fd, data, size) < ssize_t(size))
         errx(1, "Error writing samples");
     close(fd);
     return size;

--- a/libs.mk
+++ b/libs.mk
@@ -108,3 +108,8 @@ C_SRC += $(DSPLIB)/StatisticsFunctions/arm_var_q15.c
 
 C_SRC += $(DSPLIB)/BasicMathFunctions/arm_add_q31.c
 
+
+C_SRC += $(DSPLIB)/MatrixFunctions/arm_mat_init_f32.c
+C_SRC += $(DSPLIB)/MatrixFunctions/arm_mat_add_f32.c
+C_SRC += $(DSPLIB)/MatrixFunctions/arm_mat_mult_f32.c
+


### PR DESCRIPTION
I've converted OscillatorTemplate to be a bit more versatile, so it can be used for stereo too. Arbitrary number of channels could be supported in another implementation, the only limitation is that multisignal generator doesn't have methods for per-sample processing.

Quadrature sine oscillator works and uses ~5% CPU on F4

Complex float operators are not strictly necessary here, I've used them for experiments and I guess they may end up useful. But's ok not to merge them.