### PR TITLE
Register patch earlier to allow changing audio format

### DIFF
--- a/Source/PatchProgram.cpp
+++ b/Source/PatchProgram.cpp
@@ -92,10 +92,10 @@ void setup(ProgramVector* pv){
 #endif /* USE_MIDI_CALLBACK */
   if(samples != NULL)
     SampleBuffer::destroy(samples);
+#include "registerpatch.cpp"
   samples = SampleBuffer::create(pv->audio_format, pv->audio_blocksize);
   if(samples == NULL)
     error(CONFIGURATION_ERROR_STATUS, "Unsupported audio format");
-#include "registerpatch.cpp"
 }
 
 void run(ProgramVector* pv){


### PR DESCRIPTION
I've confirmed that it's possible to update audio_format and choose number of channels based on values set by PATCHIN/PATCHOUT env vars in Daisy firmware

Note that audio_format value is set in program vector before patch runs. At that time the number of configured channels is not known yet. So we can't determine required number of channels yet when ProgramManager::updateProgramVector is called, but we must do it before the patch calls  `samples = SampleBuffer::create(pv->audio_format, pv->audio_blocksize);`