### PR TITLE
fix for UpSampler::process

### DIFF
--- a/LibSource/Resample.h
+++ b/LibSource/Resample.h
@@ -102,8 +102,10 @@ public:
     ASSERT(input.getSize()*factor==output.getSize(), "wrong size");
     float* p = output;
     output.clear();
-    for(size_t i=0; i<input.getSize(); i+= factor)
-      *p++ = input[i];
+    for (size_t i = 0; i < input.getSize(); ++i) {
+      *p = input[i];
+      p += factor;
+    }
     filter->process(output, output);
   }
 };


### PR DESCRIPTION
I changed the for loop so that it copies all values out of input into output skipping `factor` samples in the output after every copy from input. I confirmed this works by including this file in the source files for a patch I'm working on in the patch library.