### PR TITLE
Print error message when platform not recognized

### DIFF
--- a/compile.mk
+++ b/compile.mk
@@ -73,6 +73,8 @@ else ifeq ($(PLATFORM),OWL3)
 ARCH_FLAGS = -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
 DEF_FLAGS = -DSTM32H7XX -DARM_MATH_CM7 -D__FPU_PRESENT=1 -D__FPU_USED=1U
 LDSCRIPT    ?= $(BUILDROOT)/Source/owl3.ld
+else
+$(error PLATFORM="$(PLATFORM)" not recognized. Known platforms: OWL0, OWL1, OWL2, OWL3. See README)
 endif
 
 ARCH_FLAGS += -fsingle-precision-constant -mthumb


### PR DESCRIPTION
Currently if the PLATFORM is not specified, it defaults to OWL2, but if the PLATFORM is *present but wrong* (IE, you specify Magus as was allowed in older versions) it prints a badly misleading error

    /usr/lib/gcc/arm-none-eabi/9.2.1/../../../arm-none-eabi/bin/ld: cannot open linker script file -fsingle-precision-constant: No such file or directory

With this patch it prints a much more helpful error:

    compile.mk:77: *** PLATFORM="Magus" not recognized. Known platforms: OWL0, OWL1, OWL2, OWL3. See README.  Stop.

I don't know if this should be added to `develop` or `master`.