### PR TITLE
Fix issue 118 - multiple definitions when compiling AdsrEnvelope

### DIFF
--- a/LibSource/AdsrEnvelope.cpp
+++ b/LibSource/AdsrEnvelope.cpp
@@ -1,0 +1,38 @@
+#include "AdsrEnvelope.h"
+
+template<>
+float AdsrEnvelope<true>::increment(float level, float amount){
+  return level + amount;
+}
+
+template<>
+float AdsrEnvelope<true>::decrement(float level, float amount){
+  return level + amount;
+}
+
+template<>
+float AdsrEnvelope<false>::increment(float level, float amount){
+  return level + (1.01-level)*amount; // aim slightly higher to ensure we reach 1.0
+}
+
+template<>
+float AdsrEnvelope<false>::decrement(float level, float amount){
+  return level + level * amount;
+}
+
+template<>
+float AdsrEnvelope<true>::calculateIncrement(float startValue, float endValue, float time){
+  return (endValue-startValue)/(sampleRate*time+1);
+}
+
+template<>
+float AdsrEnvelope<false>::calculateIncrement(float startValue, float endValue, float time) {
+  // Ref: Christian Schoenebeck http://www.musicdsp.org/showone.php?id=189
+  return (logf(endValue) - logf(startValue)) / (time*sampleRate+10);
+}
+
+template<>
+const float AdsrEnvelope<true>::MINLEVEL = 0;
+
+template<>
+const float AdsrEnvelope<false>::MINLEVEL = 0.00001; // -100dB

--- a/LibSource/AdsrEnvelope.h
+++ b/LibSource/AdsrEnvelope.h
@@ -168,43 +168,6 @@ protected:
   int gateTime;
 };
 
-template<>
-float AdsrEnvelope<true>::increment(float level, float amount){
-  return level + amount;
-}
-
-template<>
-float AdsrEnvelope<true>::decrement(float level, float amount){
-  return level + amount;
-}
-
-template<>
-float AdsrEnvelope<false>::increment(float level, float amount){
-  return level + (1.01-level)*amount; // aim slightly higher to ensure we reach 1.0
-}
-
-template<>
-float AdsrEnvelope<false>::decrement(float level, float amount){
-  return level + level * amount;
-}
-
-template<>
-float AdsrEnvelope<true>::calculateIncrement(float startValue, float endValue, float time){
-  return (endValue-startValue)/(sampleRate*time+1);
-}
-
-template<>
-float AdsrEnvelope<false>::calculateIncrement(float startValue, float endValue, float time) {
-  // Ref: Christian Schoenebeck http://www.musicdsp.org/showone.php?id=189
-  return (logf(endValue) - logf(startValue)) / (time*sampleRate+10);
-}
-
-template<>
-const float AdsrEnvelope<true>::MINLEVEL = 0;
-
-template<>
-const float AdsrEnvelope<false>::MINLEVEL = 0.00001; // -100dB
-
 typedef AdsrEnvelope<true> LinearAdsrEnvelope;
 typedef AdsrEnvelope<false> ExponentialAdsrEnvelope;
 


### PR DESCRIPTION
This fixes the linker issue where multiple definitions are present for the specialized AdsrEnvelope functions, by moving these specialized functions into a new .cpp file.

Because these are specialized for specific types, they shouldn't be included in multiple source files.

Tested using the repro steps in issue #118.